### PR TITLE
fix: harden-ssh — post-reload health check + moved to post-install (closes #50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   preventing permanent SSH lockout on fresh Ubuntu 24.04 installs.
   (`harden/harden-ssh.sh`)
 
+### Changed
+
+- **harden-ssh.sh is no longer called during install-stack** — SSH hardening
+  is now a post-install step, not a required stage. Run manually when ready:
+  `bash /usr/lib/litesoup/harden/harden-ssh.sh [--no-root-login] [--no-password-auth]`.
+  The script is still installed to `/usr/lib/litesoup/harden/` during stage 17.
+  (`install/install-stack.sh`)
+
 ## [0.10.0] - 2026-07-15
 
 ### Added (issues #46, #47)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Fixed (issue #50)
+
+- **harden-ssh.sh: post-reload health check** — After `systemctl reload ssh`,
+  the script now polls 3×2 seconds for sshd to be actively listening on the
+  configured port (detected via `SSH_CONNECTION` or `sshd -T`). If the check
+  fails, the override is reverted and sshd restarted with the original config,
+  preventing permanent SSH lockout on fresh Ubuntu 24.04 installs.
+  (`harden/harden-ssh.sh`)
+
 ## [0.10.0] - 2026-07-15
 
 ### Added (issues #46, #47)

--- a/harden/harden-ssh.sh
+++ b/harden/harden-ssh.sh
@@ -200,7 +200,9 @@ EOF
     fi
     rm -f /tmp/litesoup-sshd-t.err
     log_info "harden-ssh: sshd -t validation ok"
-    [ -n "${backup}" ] && rm -f "${backup}"
+    # NOTE: backup is intentionally NOT cleaned up here. We keep it until
+    # AFTER the reload health check (step 5b), so a runtime reload failure
+    # can still be rolled back.
   fi
 
   # 5. Reload only if we changed something. NEVER restart — that would drop
@@ -208,8 +210,55 @@ EOF
   #    `ssh.service` (not sshd.service).
   if [ "${CHANGED:-0}" = "1" ]; then
     run_or_dryrun systemctl reload ssh
+
+    # 5b. POST-RELOAD HEALTH CHECK (issue #50). `sshd -t` validates syntax
+    #     but `systemctl reload ssh` can still fail at runtime — sshd may
+    #     silently fail during re-exec on some OpenSSH / Ubuntu combos,
+    #     leaving port 22 with "Connection refused".  Poll up to 6 seconds
+    #     for the listener to come back.
+    if [ "${DRY_RUN}" != "1" ]; then
+      local ssh_port=22
+      if [ -n "${SSH_CONNECTION:-}" ]; then
+        # Port we are actually connected on — best signal.
+        ssh_port="$(echo "${SSH_CONNECTION}" | awk '{print $4}')"
+      else
+        # Fallback: read the effective configured port.
+        ssh_port="$(sshd -T 2>/dev/null | sed -n 's/^port //p' | tail -1)"
+        ssh_port="${ssh_port:-22}"
+      fi
+      local poll_ok=0
+      local i
+      for i in 1 2 3; do
+        sleep 2
+        if pgrep -x sshd >/dev/null 2>&1 && \
+           ss -tlnp 2>/dev/null | grep -qE ":${ssh_port}\b"; then
+          poll_ok=1
+          break
+        fi
+      done
+      if [ "${poll_ok}" != "1" ]; then
+        log_error "harden-ssh: HEALTH CHECK FAILED — sshd not listening on port ${ssh_port} after reload"
+        log_error "harden-ssh: Reverting ${OVERRIDE_FILE} and restarting sshd..."
+        if [ -n "${backup:-}" ]; then
+          install -m 0644 -o root -g root "${backup}" "${OVERRIDE_FILE}"
+          rm -f "${backup}"
+        else
+          rm -f "${OVERRIDE_FILE}"
+        fi
+        # Force restart — will terminate this session, but the original
+        # config is restored so the admin can reconnect.
+        systemctl restart ssh 2>/dev/null || true
+        log_error "harden-ssh: sshd restarted with original config. Reconnect via SSH."
+        exit 1
+      fi
+      log_info "harden-ssh: health check ok — sshd listening on port ${ssh_port}"
+      # Reload succeeded — safe to discard the backup now.
+      [ -n "${backup:-}" ] && rm -f "${backup}"
+    fi
   else
     log_info "harden-ssh: no override changes — skipping reload"
+    # No reload happened — clean up the backup we kept for the health check.
+    [ -n "${backup:-}" ] && rm -f "${backup}"
   fi
 
   # 6. Print active hardening directives (skipped in dry-run since the file

--- a/install/install-stack.sh
+++ b/install/install-stack.sh
@@ -125,10 +125,11 @@ main() {
   require_root
   require_ubuntu_2404
 
-  # Stage count: without --skip-hardening, composer (9) + node (10) + hardening/stages 11-18 run.
-  # With --skip-hardening, stages 9-12 run (composer + node + install scripts + litesoup-cli).
-  local total_stages=18
-  [ "${skip_hardening}" = "1" ] && total_stages=12
+  # Stage count: without --skip-hardening, hardening/stages 11-16 run (harden-ssh.sh
+  # is NOT included — it's a post-install step, run `bash harden/harden-ssh.sh`
+  # manually when ready). With --skip-hardening, stages 9-11 run.
+  local total_stages=17
+  [ "${skip_hardening}" = "1" ] && total_stages=11
 
   log_info "stage 1/${total_stages}: apache"
   ensure_apache
@@ -214,28 +215,18 @@ main() {
   log_info "stage 13/${total_stages}: harden-unattended-upgrades"
   run_or_dryrun bash "${harden_dir}/harden-unattended-upgrades.sh"
 
-  # Hardening stages 14-16 added in v0.7.0. CRITICAL: harden-ssh disables
-  # PasswordAuthentication. If you bootstrap a host via password-only SSH
-  # (e.g., fresh DO droplet's root password), running install-stack will
-  # lock you out on next session. Always set up an SSH key BEFORE running
-  # install-stack on a new host. The script writes /etc/ssh/sshd_config.d/
-  # so you can re-enable password auth via a higher-numbered file if you
-  # explicitly want it (see /etc/ssh/sshd_config.d/52-litesoup-harden.conf).
-  #
-  # v0.10.1+: harden-ssh.sh now includes a POST-RELOAD health check (issue #50).
-  # After `systemctl reload ssh`, it polls 3x2s for sshd to be listening on
-  # the active port. If the check fails, the override is reverted and sshd
-  # restarted with original config, preventing permanent lockout.
-  log_info "stage 14/${total_stages}: harden-ssh (always-safe defaults; --no-password-auth / --no-root-login are opt-in)"
-  run_or_dryrun bash "${harden_dir}/harden-ssh.sh"
+  # NOTE: harden-ssh.sh is NOT called during install-stack. It's available as
+  # a post-install step: run `bash /usr/lib/litesoup/harden/harden-ssh.sh`
+  # when ready. This avoids any risk of SSH lockout during initial provisioning.
+  # See harden/harden-ssh.sh for options (--no-root-login, --no-password-auth).
 
-  log_info "stage 15/${total_stages}: harden-apache (ServerTokens, headers, mod_status local-only)"
+  log_info "stage 14/${total_stages}: harden-apache (ServerTokens, headers, mod_status local-only)"
   run_or_dryrun bash "${harden_dir}/harden-apache.sh"
 
-  log_info "stage 16/${total_stages}: harden-php (php.ini hardening per version)"
+  log_info "stage 15/${total_stages}: harden-php (php.ini hardening per version)"
   run_or_dryrun bash "${harden_dir}/harden-php.sh"
 
-  log_info "stage 17/${total_stages}: harden-user (litesoup SSH user + sudo)"
+  log_info "stage 16/${total_stages}: harden-user (litesoup SSH user + sudo)"
   # Only runs if --ssh-key was passed; otherwise it's a no-op.
   if [ -n "${SSH_KEY:-}" ]; then
     run_or_dryrun bash "${harden_dir}/harden-user.sh" --ssh-key="${SSH_KEY}"
@@ -243,7 +234,7 @@ main() {
 
   fi  # end of skip_hardening else block
 
-  log_info "stage 18/${total_stages}: install scripts to /usr/lib/litesoup"
+  log_info "stage 17/${total_stages}: install scripts to /usr/lib/litesoup"
   run_or_dryrun install -d -m 0755 "${litesoup_lib}"
   for dir in install site harden audit; do
     run_or_dryrun install -d -m 0755 "${litesoup_lib}/${dir}"
@@ -285,7 +276,7 @@ main() {
     run_or_dryrun cp "${repo_root}/templates/apache/default-index.html" /var/www/html/index.html
   fi
 
-  log_info "stage 18/${total_stages}: install litesoup-cli (optional)"
+  log_info "stage 17/${total_stages}: install litesoup-cli (optional)"
   local cli_install_url="https://raw.githubusercontent.com/litesoup/litesoup-cli/main/install.sh"
   if command -v curl &>/dev/null; then
     local _cli_tmp

--- a/install/install-stack.sh
+++ b/install/install-stack.sh
@@ -221,6 +221,11 @@ main() {
   # install-stack on a new host. The script writes /etc/ssh/sshd_config.d/
   # so you can re-enable password auth via a higher-numbered file if you
   # explicitly want it (see /etc/ssh/sshd_config.d/52-litesoup-harden.conf).
+  #
+  # v0.10.1+: harden-ssh.sh now includes a POST-RELOAD health check (issue #50).
+  # After `systemctl reload ssh`, it polls 3x2s for sshd to be listening on
+  # the active port. If the check fails, the override is reverted and sshd
+  # restarted with original config, preventing permanent lockout.
   log_info "stage 14/${total_stages}: harden-ssh (always-safe defaults; --no-password-auth / --no-root-login are opt-in)"
   run_or_dryrun bash "${harden_dir}/harden-ssh.sh"
 


### PR DESCRIPTION
## Summary

Fixes #50 — harden-ssh.sh causes permanent SSH lockout on fresh Ubuntu 24.04 installs when `systemctl reload ssh` succeeds in sending SIGHUP but sshd fails to re-exec and bind the listener.

Two changes:

### 1. Post-reload health check (`harden/harden-ssh.sh`)

`sshd -t` validates config syntax but `systemctl reload ssh` can still fail at runtime. The backup is now kept until AFTER a health check verifies sshd survived the reload.

| What | Detail |
|------|--------|
| **Detection** | Poll 3×2s: `pgrep -x sshd` + `ss -tlnp` on active port (`$SSH_CONNECTION` or `sshd -T`) |
| **On failure** | Revert the override + `systemctl restart ssh` with original config |
| **On success** | Delete backup — reload verified OK |

### 2. Moved to post-install (`install/install-stack.sh`)

harden-ssh.sh is no longer called during install-stack. It's a **post-install step** — the admin runs it manually when ready:

```bash
bash /usr/lib/litesoup/harden/harden-ssh.sh
# or with opt-in flags:
bash /usr/lib/litesoup/harden/harden-ssh.sh --no-root-login --no-password-auth
```

The script is still installed to `/usr/lib/litesoup/harden/` during stage 17.

## Files changed

| File | Change |
|------|--------|
| `harden/harden-ssh.sh` | Post-reload health check + backup kept until reload verified |
| `install/install-stack.sh` | Removed stage 14 (harden-ssh), renumbered stages 17→17, total 18→17 |
| `CHANGELOG.md` | v0.10.1 unreleased entry