### PR TITLE
fix: NodeSource GPG key — use official setup script for Node.js 22.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   The script is still installed to `/usr/lib/litesoup/harden/` during stage 17.
   (`install/install-stack.sh`)
 
+### Fixed
+
+- **NodeSource GPG key for Node.js 22.x** — Stage 10 now uses the official
+  NodeSource setup script instead of manual `gpg --dearmor` key import, which
+  `apt-get update` rejected on Ubuntu 24.04. (`install/install-stack.sh`)
+
 ## [0.10.0] - 2026-07-15
 
 ### Added (issues #46, #47)

--- a/install/install-stack.sh
+++ b/install/install-stack.sh
@@ -172,15 +172,15 @@ main() {
   log_info "stage 10/${total_stages}: node.js + npm"
   if ! command -v node &>/dev/null; then
     # Nodesource setup for Node.js 22.x LTS
+    # NOTE: The old gpg --dearmor method produces a key that apt rejects
+    # on Ubuntu 24.04. Use the official setup script instead.
     if [ "${DRY_RUN:-0}" != "1" ]; then
       if ! command -v node &>/dev/null; then
-        apt_install ca-certificates curl gnupg
-        mkdir -p /etc/apt/keyrings
-        curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-          | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg 2>/dev/null || true
-        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
-          > /etc/apt/sources.list.d/nodesource.list
-        apt-get update -qq && apt_install nodejs
+        apt_install ca-certificates curl
+        curl -fsSL https://deb.nodesource.com/setup_22.x -o /tmp/nodesetup.sh
+        bash /tmp/nodesetup.sh
+        apt-get install -y nodejs
+        rm -f /tmp/nodesetup.sh
       fi
     else
       log_info "  [dry-run] would install nodejs from nodesource"


### PR DESCRIPTION
## Summary

Fixes stage 10 failure on Ubuntu 24.04: the manual `gpg --dearmor` key import produces a key that `apt-get update` rejects (`NO_PUBKEY` / unsigned repository).

## Fix

Replace broken GPG import with official NodeSource setup script:

Error: This script is only supported on Debian-based systems.

## Related

Part of the sg10 deploy fix (issue #50) — the last run failed here after the harden-ssh fix was already merged.