### PR TITLE
fix: backup-install.sh copies onto itself when run from installed location (closes #54)

### DIFF
--- a/backup/backup-install.sh
+++ b/backup/backup-install.sh
@@ -121,19 +121,28 @@ S3EOF
     fi
   fi
 
-  # 4. Copy backup scripts to /usr/lib/litesoup/backup/
-  log_info "backup-install: installing backup scripts to ${LITESOUP_LIB}/backup/"
-  if [ "${DRY_RUN}" = "1" ]; then
-    log_info "[DRYRUN] would install backup/*.sh -> ${LITESOUP_LIB}/backup/"
+  # 4. Copy backup scripts to /usr/lib/litesoup/backup/ (skip when already
+  #    installed — running from the installed directory makes source and
+  #    destination the same file, which `install` refuses).
+  local backup_src
+  backup_src="$(cd "${REPO_ROOT}/backup" && pwd)"
+  local backup_dst="${LITESOUP_LIB}/backup"
+  if [ "${backup_src}" = "$(cd "${backup_dst}" 2>/dev/null && pwd || echo '')" ]; then
+    log_info "backup-install: already installed — skipping script copy"
   else
-    run_or_dryrun mkdir -p "${LITESOUP_LIB}/backup/lib"
-    for f in "${REPO_ROOT}/backup/"*.sh; do
-      run_or_dryrun install -m 0755 "${f}" "${LITESOUP_LIB}/backup/"
-    done
-    for f in "${REPO_ROOT}/backup/lib/"*.sh; do
-      run_or_dryrun install -m 0644 "${f}" "${LITESOUP_LIB}/backup/lib/"
-    done
-    run_or_dryrun install -m 0644 "${REPO_ROOT}/install/lib/notify.sh" "${LITESOUP_LIB}/install/lib/"
+    log_info "backup-install: installing backup scripts to ${backup_dst}/"
+    if [ "${DRY_RUN}" = "1" ]; then
+      log_info "[DRYRUN] would install backup/*.sh -> ${backup_dst}/"
+    else
+      run_or_dryrun mkdir -p "${backup_dst}/lib"
+      for f in "${REPO_ROOT}/backup/"*.sh; do
+        run_or_dryrun install -m 0755 "${f}" "${backup_dst}/"
+      done
+      for f in "${REPO_ROOT}/backup/lib/"*.sh; do
+        run_or_dryrun install -m 0644 "${f}" "${backup_dst}/lib/"
+      done
+      run_or_dryrun install -m 0644 "${REPO_ROOT}/install/lib/notify.sh" "${LITESOUP_LIB}/install/lib/"
+    fi
   fi
 
   # 5. Create backup directories for existing site users


### PR DESCRIPTION
## Summary

`litesoup backup configure` fails because the CLI runs `backup-install.sh` from `/usr/lib/litesoup/backup/`, making `REPO_ROOT` resolve to `/usr/lib/litesoup`. The copy loop then tries to `install` files from `REPO_ROOT/backup/` to `LITESOUP_LIB/backup/` — which are the same directory.

## Fix

Compare resolved source and destination paths before copying. If they match, the scripts are already installed — skip the copy step and log a message.

## Verification

- [x] Running from clone: `REPO_ROOT/backup/` ≠ `/usr/lib/litesoup/backup/` → copy runs normally
- [x] Running from installed location: `REPO_ROOT/backup/` = `/usr/lib/litesoup/backup/` → skip copy
- [x] Dry-run mode unaffected