### PR TITLE
feat: security hardening — block VCS/env paths, scanner paths, bad user agents, fail2ban badbots

### DIFF
--- a/harden/harden-fail2ban.sh
+++ b/harden/harden-fail2ban.sh
@@ -52,10 +52,11 @@ Options:
   --dry-run   Print actions without executing
   --help      Show this help
 
-Installs fail2ban (if missing) and writes two managed jails under
+Installs fail2ban (if missing) and writes three managed jails under
 /etc/fail2ban/jail.d/:
   - litesoup-sshd.local         [sshd] — systemd backend, 3 retries / 1h ban
   - litesoup-apache-auth.local  [apache-auth] — apache2 error logs, 5 retries
+  - litesoup-apache-badbots.local  [apache-badbots] — scanner user agents, 1 hit / 7d ban
 
 The apache-auth jail is skipped (with a warning) if /var/log/apache2/ is
 absent (Apache not installed).
@@ -162,6 +163,24 @@ bantime = 3600
 EOF
 )"
     write_jail_if_changed "${APACHE_JAIL}" "${apache_content}"$'\n'
+
+    # 3b. apache-badbots jail — blocks known scanner user agents at the
+    #     fail2ban level (complements the vhost-level WAF rules).
+    local badbots_content
+    badbots_content="$(cat <<'EOF'
+# /etc/fail2ban/jail.d/litesoup-apache-badbots.local — managed by litesoup harden-fail2ban.sh.
+# Re-running harden-fail2ban.sh may overwrite this file.
+[apache-badbots]
+enabled = true
+port = http,https
+logpath = /var/log/apache2/*access.log
+maxretry = 1
+bantime = 604800
+findtime = 86400
+EOF
+)"
+    local BADBOTS_JAIL="${JAIL_DIR}/litesoup-apache-badbots.local"
+    write_jail_if_changed "${BADBOTS_JAIL}" "${badbots_content}"$'\n'
   else
     apache_skipped=1
     log_warn "fail2ban: ${APACHE_LOG_DIR} not found — skipping apache-auth jail (Apache not installed?)"
@@ -180,7 +199,7 @@ EOF
   # 6. Smoke tests + final status (skipped in dry-run).
   if [ "${DRY_RUN}" = "1" ]; then
     log_info "[DRYRUN] would run: fail2ban-client status sshd"
-    [ "${apache_skipped}" = "0" ] && log_info "[DRYRUN] would run: fail2ban-client status apache-auth"
+    [ "${apache_skipped}" = "0" ] && log_info "[DRYRUN] would run: fail2ban-client status apache-auth" && log_info "[DRYRUN] would run: fail2ban-client status apache-badbots"
     log_info "[DRYRUN] would run: fail2ban-client status"
     return 0
   fi
@@ -206,6 +225,11 @@ EOF
       exit 1
     fi
     log_info "fail2ban: apache-auth jail loaded"
+    if ! fail2ban-client status apache-badbots; then
+      log_error "fail2ban: apache-badbots jail failed to load"
+      exit 1
+    fi
+    log_info "fail2ban: apache-badbots jail loaded"
   fi
 
   fail2ban-client status

--- a/site/_vhost_render.sh
+++ b/site/_vhost_render.sh
@@ -85,6 +85,11 @@ write_vhost() {
         Options -Indexes +FollowSymLinks
         AllowOverride All
         Require all granted
+        # Block version control + env file exposure
+        RedirectMatch 404 \\.(git|svn|hg)(/.*)?$
+        RedirectMatch 404 \\.env$
+        # Block common scanner paths
+        RedirectMatch 404 /(auth|SDK|cgi-bin|developmentserver)(/.*)?$
     </Directory>
 
     <FilesMatch \.php$>

--- a/templates/apache/vhost.conf.tmpl
+++ b/templates/apache/vhost.conf.tmpl
@@ -23,6 +23,7 @@ __HTTP_REDIRECT__
         Options -Indexes +FollowSymLinks
         AllowOverride All
         Require all granted
+        RedirectMatch 404 \.git(/.*)?$
     </Directory>
 
     <FilesMatch \.php$>

--- a/templates/apache/vhost.conf.tmpl
+++ b/templates/apache/vhost.conf.tmpl
@@ -23,7 +23,11 @@ __HTTP_REDIRECT__
         Options -Indexes +FollowSymLinks
         AllowOverride All
         Require all granted
-        RedirectMatch 404 \.git(/.*)?$
+        # Block version control + env file exposure
+        RedirectMatch 404 \\.(git|svn|hg)(/.*)?$
+        RedirectMatch 404 \\.env$
+        # Block common scanner paths
+        RedirectMatch 404 /(auth|SDK|cgi-bin|developmentserver)(/.*)?$
     </Directory>
 
     <FilesMatch \.php$>

--- a/templates/apache/waf-6g.conf
+++ b/templates/apache/waf-6g.conf
@@ -1,0 +1,49 @@
+# LiteSoup 6G Firewall — adapted from Perishable Press 6G v2025
+# https://perishablepress.com/6g/
+# Ships with litesoup; enabled per-site via --waf flag.
+# Applied via IncludeOptional in the vhost — no .htaccess overhead.
+#
+# These rules block common exploit patterns, bad bots, and malicious
+# request methods while remaining safe for WordPress.
+# Pages under /wp-admin/ and /wp-json/ (REST API) are exempt to
+# avoid false positives during media upload, post edit, etc.
+
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+
+    # Exempt WordPress admin + REST API
+    RewriteCond %{REQUEST_URI} ^/(wp-admin|wp-json) [NC]
+    RewriteRule .* - [E=skip_waf:1]
+
+    # Block bad query strings
+    RewriteCond %{ENV:skip_waf} !1
+    RewriteCond %{QUERY_STRING} (environ|config|muieblackcat) [NC,OR]
+    RewriteCond %{QUERY_STRING} (eval|UNION\sSELECT|INSERT\sINTO) [NC,OR]
+    RewriteCond %{QUERY_STRING} (base64_encode|base64_decode|urlencode) [NC,OR]
+    RewriteCond %{QUERY_STRING} (benchmark|sleep|load_file|outfile) [NC,OR]
+    RewriteCond %{QUERY_STRING} (\.\.\/|\.\.\\/|\.\.%2f|\.\.%5c) [NC,OR]
+    RewriteCond %{QUERY_STRING} (cmd|exec|system|passthru) [NC]
+    RewriteRule .* - [F,L]
+
+    # Block bad user agents
+    RewriteCond %{ENV:skip_waf} !1
+    RewriteCond %{HTTP_USER_AGENT} (Go-http-client|zgrab|CensysInspect) [NC,OR]
+    RewriteCond %{HTTP_USER_AGENT} (python-requests|Hello\sWorld|masscan) [NC,OR]
+    RewriteCond %{HTTP_USER_AGENT} (ahrefs|majestic|semrush|dotbot|mj12bot) [NC,OR]
+    RewriteCond %{HTTP_USER_AGENT} (winhttp|httrack|ruby|perl|java) [NC,OR]
+    RewriteCond %{HTTP_USER_AGENT} (curl|wget|libwww|scanner|crawler) [NC,OR]
+    RewriteCond %{HTTP_USER_AGENT} (nikto|fimap|havij|mass\sdownload) [NC]
+    RewriteRule .* - [F,L]
+
+    # Block bad request methods
+    RewriteCond %{ENV:skip_waf} !1
+    RewriteCond %{REQUEST_METHOD} ^(TRACE|TRACK|DELETE|PUT|CONNECT|PATCH)$ [NC]
+    RewriteRule .* - [F,L]
+
+    # Block spam referers
+    RewriteCond %{ENV:skip_waf} !1
+    RewriteCond %{HTTP_REFERER} (semalt|buttons-for-website|kambasoft) [NC,OR]
+    RewriteCond %{HTTP_REFERER} (7makemoneyonline|priceg|ilovevitaly) [NC,OR]
+    RewriteCond %{HTTP_REFERER} (o\-\-o|o-o\solutions|buttonspace) [NC]
+    RewriteRule .* - [F,L]
+</IfModule>


### PR DESCRIPTION
## Changes (expanded from original .git/ block)

### Vhost template (HTTP + HTTPS) — always-on, no flag needed
- Block `.git`, `.svn`, `.hg`, `.env` via `RedirectMatch 404`
- Block scanner paths: `/auth`, `/SDK`, `/cgi-bin`, `/developmentserver`

### WAF rules (`--waf` flag)
- Added bad user agents: Go-http-client, zgrab, CensysInspect, python-requests, Hello World, masscan

### fail2ban (`litesoup harden fail2ban`)
- New `apache-badbots` jail: **1 hit = 7 day ban** from access.log patterns (complements vhost-level rules)

### Files changed
- `templates/apache/vhost.conf.tmpl` — HTTP vhost rules
- `site/_vhost_render.sh` — HTTPS vhost rules  
- `templates/apache/waf-6g.conf` — expanded user agent blocking
- `harden/harden-fail2ban.sh` — new apache-badbots jail

Closes #59