### PR TITLE
feat: block PHP execution in wp-content/uploads and debug.log access

### DIFF
--- a/site/_vhost_render.sh
+++ b/site/_vhost_render.sh
@@ -87,6 +87,18 @@ write_vhost() {
         Require all granted
     </Directory>
 
+    # Block PHP execution in wp-content/uploads (mitigates file-upload RCE)
+    <Directory ${VHOST_DOCROOT}/wp-content/uploads>
+        <FilesMatch \.php$>
+            Require all denied
+        </FilesMatch>
+    </Directory>
+
+    # Block direct access to wp-content/debug.log (prevents credential leaks)
+    <Files "debug.log">
+        Require all denied
+    </Files>
+
     <FilesMatch \.php$>
         SetHandler "proxy:unix:${socket}|fcgi://localhost"
     </FilesMatch>

--- a/templates/apache/vhost.conf.tmpl
+++ b/templates/apache/vhost.conf.tmpl
@@ -25,6 +25,18 @@ __HTTP_REDIRECT__
         Require all granted
     </Directory>
 
+    # Block PHP execution in wp-content/uploads (mitigates file-upload RCE)
+    <Directory __DOCROOT__/wp-content/uploads>
+        <FilesMatch \.php$>
+            Require all denied
+        </FilesMatch>
+    </Directory>
+
+    # Block direct access to wp-content/debug.log (prevents credential leaks)
+    <Files "debug.log">
+        Require all denied
+    </Files>
+
     <FilesMatch \.php$>
         SetHandler "proxy:unix:__FPM_SOCKET__|fcgi://localhost"
     </FilesMatch>


### PR DESCRIPTION
## Problem

WordPress sites on LiteSoup don't block:
1. PHP execution inside `wp-content/uploads/` — file-upload RCE vector
2. Direct access to `wp-content/debug.log` — credential leak when WP_DEBUG is on

## Changes

- **vhost.conf.tmpl**: Add `<Directory wp-content/uploads>` block with `<FilesMatch \.php$> Require all denied` + `<Files "debug.log"> Require all denied`
- **_vhost_render.sh**: Same rules for HTTPS vhost

Closes #62