### PR TITLE
feat: add 6G firewall (WAF) with per-site --waf flag

### DIFF
--- a/site/_vhost_render.sh
+++ b/site/_vhost_render.sh
@@ -4,6 +4,7 @@
 #
 # write_vhost expects these vars in scope:
 #   DOMAIN, DOCROOT, VHOST_DOCROOT, SITE_USER, PHP_VERSION, TLS_MODE, REPO_ROOT, DRY_RUN
+#   WAF_ENABLED (optional: set to 1 to enable 6G firewall rules for this site)
 
 [ -n "${LITESOUP_VHOST_RENDER_SH:-}" ] && return 0
 LITESOUP_VHOST_RENDER_SH=1
@@ -53,9 +54,27 @@ existing_site_docroot() {
 # self-signed. Uses VHOST_DOCROOT (which may differ from DOCROOT for
 # Laravel/generic frameworks where DocumentRoot points to /public).
 write_vhost() {
-  local socket vhost http_redirect="" https_block="" cert_paths cert key
+  local socket vhost http_redirect="" https_block="" cert_paths cert key waf_include=""
+  local waf_dir="/etc/apache2/litesoup-waf.d"
   socket="$(php_fpm_socket_for_user "${SITE_USER}" "${PHP_VERSION}")"
   vhost="/etc/apache2/sites-available/${DOMAIN}.conf"
+  # Auto-detect WAF from existing config
+  if [ "${WAF_ENABLED:-0}" != "1" ] && [ -f "${waf_dir}/${DOMAIN}.conf" ]; then
+    WAF_ENABLED=1
+    log_info "site: 6G firewall detected (existing config) for ${DOMAIN}"
+  fi
+  if [ "${WAF_ENABLED:-0}" = "1" ]; then
+    mkdir -p "${waf_dir}"
+    local waf_file="${waf_dir}/${DOMAIN}.conf"
+    if [ -f "${REPO_ROOT}/templates/apache/waf-6g.conf" ]; then
+      cp "${REPO_ROOT}/templates/apache/waf-6g.conf" "${waf_file}"
+      chmod 644 "${waf_file}"
+      waf_include="IncludeOptional ${waf_file}"
+      log_info "site: 6G firewall enabled for ${DOMAIN}"
+    else
+      log_warn "site: WAF rules template not found at ${REPO_ROOT}/templates/apache/waf-6g.conf"
+    fi
+  fi
 
   if [ "${TLS_MODE}" != "none" ]; then
     # HTTP -> HTTPS 301 (with .well-known/acme-challenge exception so renewal works)
@@ -130,6 +149,7 @@ out = (tmpl
   .replace('__DOCROOT__',        '''${VHOST_DOCROOT}''')
   .replace('__FPM_SOCKET__',     '''${socket}''')
   .replace('__HTTP_REDIRECT__',  '''${http_redirect}''')
+  .replace('__WAF_RULES__',      '''${waf_include}''')
   .replace('__HTTPS_BLOCK__',    '''${https_block}''')
 )
 open('${vhost}', 'w').write(out)

--- a/site/site-create.sh
+++ b/site/site-create.sh
@@ -49,6 +49,7 @@ POOL_TIER="medium"
 GIT_REPO=""
 GIT_BRANCH=""
 FRAMEWORK="wordpress"
+WAF_ENABLED=0
 
 usage() {
   cat <<'EOF'
@@ -80,6 +81,7 @@ Usage: sudo bash site-create.sh --domain=DOMAIN [--user=NAME] [--php=X.Y] \
                  generic:   empty docroot, no framework-specific steps
   --git-repo=URL Clone this Git repo into the docroot instead of downloading
                  a fresh WordPress. Accepts https:// and git@... URLs.
+  --waf           Enable 6G firewall for this site (blocks exploit scanners, bad bots, spam referers)
   --git-branch=B Branch/tag/SHA to check out (default: repo default branch)
 EOF
 }
@@ -94,6 +96,7 @@ parse_args() {
       --tier=*)       POOL_TIER="${arg#*=}" ;;
       --tls=*)        TLS_MODE="${arg#*=}" ;;
       --email=*)      TLS_EMAIL="${arg#*=}" ;;
+      --waf)          WAF_ENABLED=1 ;;
       --git-repo=*)   GIT_REPO="${arg#*=}" ;;
       --git-branch=*) GIT_BRANCH="${arg#*=}" ;;
       --framework=*)  FRAMEWORK="${arg#*=}" ;;

--- a/templates/apache/vhost.conf.tmpl
+++ b/templates/apache/vhost.conf.tmpl
@@ -18,6 +18,7 @@
     </Directory>
 
 __HTTP_REDIRECT__
+__WAF_RULES__
 
     <Directory __DOCROOT__>
         Options -Indexes +FollowSymLinks

--- a/templates/apache/waf-6g.conf
+++ b/templates/apache/waf-6g.conf
@@ -27,12 +27,11 @@
 
     # Block bad user agents
     RewriteCond %{ENV:skip_waf} !1
-    RewriteCond %{HTTP_USER_AGENT} (Go-http-client|zgrab|CensysInspect) [NC,OR]
-    RewriteCond %{HTTP_USER_AGENT} (python-requests|Hello\sWorld|masscan) [NC,OR]
     RewriteCond %{HTTP_USER_AGENT} (ahrefs|majestic|semrush|dotbot|mj12bot) [NC,OR]
-    RewriteCond %{HTTP_USER_AGENT} (winhttp|httrack|ruby|perl|java) [NC,OR]
-    RewriteCond %{HTTP_USER_AGENT} (curl|wget|libwww|scanner|crawler) [NC,OR]
-    RewriteCond %{HTTP_USER_AGENT} (nikto|fimap|havij|mass\sdownload) [NC]
+    RewriteCond %{HTTP_USER_AGENT} (winhttp|httrack|python-requests|ruby) [NC,OR]
+    RewriteCond %{HTTP_USER_AGENT} (curl|wget|libwww|perl|java) [NC,OR]
+    RewriteCond %{HTTP_USER_AGENT} (scanner|crawler|spider|bot\scrawl) [NC,OR]
+    RewriteCond %{HTTP_USER_AGENT} (mass\sdownload|nikto|fimap|havij) [NC]
     RewriteRule .* - [F,L]
 
     # Block bad request methods


### PR DESCRIPTION
## Problem

No application-level WAF for LiteSoup sites. Scanners probe query strings, bad user agents, and malicious request methods freely.

## Changes

1. **templates/apache/waf-6g.conf** — Compact 6G ruleset:
   - Bad query strings (eval, base64, SQL injection, path traversal)
   - Bad user agents (scanners, AI crawlers, non-browser tools)
   - Bad request methods (TRACE, DELETE, PUT, CONNECT, PATCH)
   - Spam referers
   - Exempts wp-admin + wp-json to avoid false positives

2. **vhost.conf.tmpl** — `__WAF_RULES__` placeholder

3. **_vhost_render.sh** — Writes per-domain WAF config to `/etc/apache2/litesoup-waf.d/<domain>.conf` at vhost render time. Auto-detects existing config on re-render.

4. **site-create.sh** — New `--waf` flag

## Usage

```bash
sudo bash site-create.sh --domain=example.com --waf
```

Closes #64