### PR TITLE
fix: remove duplicate bats test name

### DIFF
--- a/test/bats/unit_backup.bats
+++ b/test/bats/unit_backup.bats
@@ -139,14 +139,6 @@ setup() {
     "${REPO_ROOT}/backup/backup-install.sh"
 }
 
-@test "backup-restore --help exits 0" {
-  if [ ! -f "${REPO_ROOT}/backup/backup-restore.sh" ]; then
-    skip "backup-restore.sh not available"
-  fi
-  run -0 bash "${REPO_ROOT}/backup/backup-restore.sh" --help
-  [[ "${output}" == *"litesoup backup-restore"* ]]
-}
-
 @test "backup-restore --dry-run without --domain fails with root error" {
   if [ ! -f "${REPO_ROOT}/backup/backup-restore.sh" ]; then
     skip "backup-restore.sh not available"


### PR DESCRIPTION
Removed duplicate @test backup-restore --help exits 0 in unit_backup.bats (was defined at lines 97 and 142).