### PR TITLE
feat: add HTTPS catch-all to 000-default vhost with snakeoil cert

### DIFF
--- a/install/install-stack.sh
+++ b/install/install-stack.sh
@@ -270,6 +270,11 @@ main() {
       "/etc/apache2/sites-available/000-default.conf"
     run_or_dryrun a2ensite 000-default.conf 2>/dev/null || true
   fi
+  # Ensure SSL snakeoil cert exists for the default vhost's port 443 catch-all.
+  # Any domain pointed at this server without its own site gets the LiteSoup
+  # landing page over HTTPS (with a browser 'Not Secure' warning) instead of
+  # falling through to another site's cert.
+  run_or_dryrun ensure_pkgs ssl-cert
 
   # Install the landing page served by the default vhost (direct IP access).
   if [ -f "${repo_root}/templates/apache/default-index.html" ]; then

--- a/install/lib/apache.sh
+++ b/install/lib/apache.sh
@@ -5,7 +5,7 @@
 LITESOUP_APACHE_SH=1
 
 ensure_apache() {
-  ensure_pkgs apache2 apache2-utils
+  ensure_pkgs apache2 apache2-utils ssl-cert
 
   # Switch to mpm_event (default mpm on Ubuntu is prefork-or-event depending; force event)
   if apache2ctl -V 2>/dev/null | grep -q 'Server MPM:.*prefork'; then

--- a/templates/apache/000-default.conf.tmpl
+++ b/templates/apache/000-default.conf.tmpl
@@ -11,3 +11,15 @@
         Require all granted
     </Directory>
 </VirtualHost>
+
+<VirtualHost _default_:443>
+    DocumentRoot /var/www/html
+    <Directory /var/www/html>
+        Options -Indexes +FollowSymLinks
+        AllowOverride None
+        Require all granted
+    </Directory>
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/ssl-cert-snakeoil.pem
+    SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
+</VirtualHost>


### PR DESCRIPTION
## What

Adds a `<VirtualHost _default_:443>` block to `000-default.conf.tmpl` with Apache's snakeoil self-signed cert so any unmapped domain pointing at a litesoup server gets the LiteSoup landing page over HTTPS instead of falling through to another site's vhost/cert.

## Changes

- `templates/apache/000-default.conf.tmpl` — Port 443 catch-all with snakeoil cert
- `install/lib/apache.sh` — `ssl-cert` package added to `ensure_apache()`
- `install/install-stack.sh` — Defensive `ensure_pkgs ssl-cert` in stage 17

Closes #71