### PR TITLE
fix: backup-site.sh timeout bash -c, permission denied, missing vhost metadata

### DIFF
--- a/backup/backup-site.sh
+++ b/backup/backup-site.sh
@@ -153,7 +153,11 @@ main() {
   if [ "${SKIP_DB}" != "1" ]; then
     local db_ts
     db_ts="$(date +%s)"
-    timeout 300 bash -c "backup_dump_db \"${DOMAIN}\" \"${backup_dir}\"" || {
+    timeout 300 bash -c "
+REPO_ROOT='${REPO_ROOT}'
+source \"\${REPO_ROOT}/backup/lib/common.sh\"
+backup_dump_db '${DOMAIN}' '${backup_dir}'
+" || {
       local db_ec=$?
       if [ "${db_ec}" -eq 124 ]; then
         notify_event "backup TIMEOUT: ${DOMAIN}" "Database dump timed out (>300s) for ${DOMAIN}"
@@ -184,7 +188,11 @@ main() {
     fi
     local fs_ts
     fs_ts="$(date +%s)"
-    timeout 600 bash -c "backup_archive \"${docroot}\" \"${files_archive}\"" || {
+    timeout 600 bash -c "
+REPO_ROOT='${REPO_ROOT}'
+source \"\${REPO_ROOT}/backup/lib/common.sh\"
+backup_archive '${docroot}' '${files_archive}'
+" || {
       local fs_ec=$?
       rm -f "${exclude_file:-}"
       if [ "${fs_ec}" -eq 124 ]; then

--- a/backup/lib/common.sh
+++ b/backup/lib/common.sh
@@ -148,6 +148,7 @@ backup_dump_db() {
   fi
 
   mkdir -p "${dest_dir}"
+  chown "${user}:${user}" "${dest_dir}"
   sudo -H -u "${user}" wp --path="${docroot}" db export "${dest_dir}/database.sql" 2>/dev/null || {
     log_error "backup: wp db export failed for ${domain}"
     return 1

--- a/site/_vhost_render.sh
+++ b/site/_vhost_render.sh
@@ -158,5 +158,15 @@ open('${vhost}', 'w').write(out)
   a2ensite "${DOMAIN}.conf" >/dev/null
   apache2ctl configtest \
     || { log_error "site-create: apache configtest failed for ${DOMAIN}"; return 1; }
+
+  # Write vhost metadata for backup scripts (backup/lib/common.sh reads this)
+  local vhost_meta_dir="/etc/litesoup/vhost"
+  mkdir -p "${vhost_meta_dir}"
+  cat > "${vhost_meta_dir}/${DOMAIN}.conf" <<VHOST_META
+SITE_USER=${SITE_USER}
+DOCROOT=${DOCROOT}
+VHOST_META
+  chmod 644 "${vhost_meta_dir}/${DOMAIN}.conf"
+
   systemctl reload apache2
 }

--- a/test/bats/unit_backup.bats
+++ b/test/bats/unit_backup.bats
@@ -193,11 +193,11 @@ setup() {
 }
 
 @test "backup-site.sh has timeout on db dump" {
-  grep -q 'timeout 300.*backup_dump_db' "${REPO_ROOT}/backup/backup-site.sh"
+  grep -qz 'timeout 300.*backup_dump_db' "${REPO_ROOT}/backup/backup-site.sh"
 }
 
 @test "backup-site.sh has timeout on file archive" {
-  grep -q 'timeout 600.*backup_archive' "${REPO_ROOT}/backup/backup-site.sh"
+  grep -qz 'timeout 600.*backup_archive' "${REPO_ROOT}/backup/backup-site.sh"
 }
 
 @test "backup-site.sh logs elapsed time" {


### PR DESCRIPTION
## Mô tả

Fixes 3 bugs in backup system reported in work item #1.

### Bug 1: `timeout bash -c` loses function context
`timeout 300 bash -c "backup_dump_db ..."` creates a new subshell that doesn't inherit bash functions from `common.sh`. Result: `backup_dump_db: command not found`.

**Fix:** Source `common.sh` inside the `bash -c` subshell via `REPO_ROOT`.

### Bug 2: Permission denied on wp db export
`mkdir -p` creates backup dir as root, then `wp db export` runs as site user who can't write to root-owned directory → `Errcode: 13 Permission denied`.

**Fix:** `chown` dest_dir to site user before running `wp db export`.

### Bug 3: Missing /etc/litesoup/vhost/ directory
Backup scripts read vhost metadata from `/etc/litesoup/vhost/<domain>.conf` but this directory was never created during site creation. On sg10 (v0.10.6), the directory doesn't exist → backup fails with "vhost config not found".

**Fix:** Write `SITE_USER` + `DOCROOT` metadata file in `write_vhost()` after Apache configtest passes.

## Files changed
- `backup/backup-site.sh` — source common.sh inside timeout bash -c subshell
- `backup/lib/common.sh` — chown backup dir to site user before db export
- `site/_vhost_render.sh` — write vhost metadata to /etc/litesoup/vhost/

Closes #1