### PR TITLE
fix: run harden-ssh before harden-firewall in install-stack to prevent SSH lockout (closes #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed (issue #75)
+
+- **install-stack hardening could lock out SSH on Ubuntu 24.04 with a
+  non-standard port** — `install-stack.sh` now runs `harden-ssh.sh` as the
+  first hardening stage, **before** `harden-firewall.sh`. Ubuntu 24.04
+  ships socket-activated SSH (`ssh.socket`), which binds the **default**
+  port regardless of the `Port` directive. Previously the firewall opened
+  the configured port (where nothing listened) while blocking the socket
+  port (where sshd actually listened) → operator locked out, console
+  recovery required.
+- **`harden-ssh.sh` now disables `ssh.socket` on every run** (not just
+  when the override file changes), switching to standalone `ssh.service`
+  which binds the configured port. This is idempotent and catches a
+  package upgrade that re-enables the socket on re-run.
+- **Post-install SSH access verification** — after hardening,
+  `install-stack.sh` runs `verify_ssh_access`, confirming sshd is listening
+  on the configured port, UFW allows it, and `ssh.socket` is disabled. It
+  aborts (rather than declaring success) if the operator is about to be
+  locked out. (`install/install-stack.sh`, `harden/harden-ssh.sh`,
+  `test/bats/unit_harden.bats`)
+
 ## [0.10.8] - 2026-08-03
 
 ### Added (feature #70)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,12 +89,18 @@ The mental model: every script is a convergence step toward a desired state, nev
 | 6 | Certbot + LE auto-renewal timer | Pulled from Ubuntu archive, no PPA needed. |
 | 7 | Redis | RAM-tier-sized maxmemory: `<2G→128mb`, `2–8G→512mb`, `≥8G→2gb`. Override with `--redis-maxmemory=SIZE`. |
 | 8 | Memcached | UDP off (`-U 0`), loopback only (`-l 127.0.0.1`). |
-| 9 | harden-firewall (ufw) | Opens 22/80/443; deny everything else. |
-| 10 | harden-fail2ban | Watches Apache + sshd logs. Has to run after stage 1 so the log files exist. |
-| 11 | harden-unattended-upgrades | Security updates only. |
-| 12 | harden-ssh | **Reads the warning in the script header before running on a fresh host** — see SSH note below. |
+| 9 | harden-ssh | Disables Ubuntu 24.04 socket-activated SSH, switches to standalone sshd on the configured port, writes safe sshd defaults. Runs before the firewall (issue #75). |
+| 10 | harden-firewall (ufw) | Opens the sshd port + 80/443; deny everything else. |
+| 11 | harden-fail2ban | Watches Apache + sshd logs. Has to run after stage 1 so the log files exist. |
+| 12 | harden-unattended-upgrades | Security updates only. |
 | 13 | harden-apache | `ServerTokens Prod`, security headers, mod_status restricted to local. |
 | 14 | harden-php | Global php.ini hardening per installed version. |
+| 15 | harden-user | Provisions `litesoup` SSH user + sudo (only when `--ssh-key` passed). |
+
+After hardening, install-stack runs `verify_ssh_access`: it confirms sshd
+is listening on the configured port, UFW allows it, and `ssh.socket` is
+disabled — aborting rather than declaring success if the operator is about
+to be locked out (issue #75).
 
 The "services first, lock down second" ordering is deliberate: every hardening stage depends on the thing it's hardening already being installed and configured. Reorder this and stage 10 fails because there are no Apache logs yet.
 

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -6,26 +6,37 @@ nav_order: 4
 
 # Server hardening
 
-`install-stack.sh` runs six hardening scripts at the end (stages 9-14)
+`install-stack.sh` runs seven hardening scripts at the end (stages 11-17)
 once the LAMP stack is up. Each script is idempotent — re-runs detect
 "already configured" and skip the work. Each script also runs standalone,
 so you can re-apply or update one piece without touching the rest. Pass
-`--skip-hardening` to install-stack to skip all six.
+`--skip-hardening` to install-stack to skip all seven.
 
 ## What runs by default
 
-- **stage 9 — harden-firewall.sh** — installs ufw, denies inbound by
+- **stage 11 — harden-ssh.sh** — disables Ubuntu 24.04 socket-activated
+  SSH (`ssh.socket`) and switches to standalone sshd on the configured
+  port, then writes safe sshd defaults. **Must run before the firewall**
+  so the port UFW opens is the one sshd actually listens on (see the
+  socket-activation note below).
+- **stage 12 — harden-firewall.sh** — installs ufw, denies inbound by
   default, opens SSH (auto-detected port) + 80/tcp + 443/tcp.
-- **stage 10 — harden-fail2ban.sh** — installs fail2ban, ships managed
+- **stage 13 — harden-fail2ban.sh** — installs fail2ban, ships managed
   jails for sshd and apache-auth.
-- **stage 11 — harden-unattended-upgrades.sh** — turns on
+- **stage 14 — harden-unattended-upgrades.sh** — turns on
   security-only auto-updates, no auto-reboot.
-- **stage 12 — harden-ssh.sh** — writes safe sshd defaults
-  (MaxAuthTries 3, idle timeout, X11/agent forwarding off).
-- **stage 13 — harden-apache.sh** — hides version banner, adds three
+- **stage 15 — harden-apache.sh** — hides version banner, adds three
   security headers, restricts `/server-status` to localhost.
-- **stage 14 — harden-php.sh** — global php.ini hardening (cli + fpm)
+- **stage 16 — harden-php.sh** — global php.ini hardening (cli + fpm)
   for every installed PHP version.
+- **stage 17 — harden-user.sh** — provisions the `litesoup` SSH user +
+  sudo (only when `--ssh-key` is passed to install-stack).
+
+After hardening, install-stack runs a **post-install SSH access check**
+(`verify_ssh_access`): it confirms sshd is listening on the configured
+port, UFW allows it, and `ssh.socket` is disabled. If any check fails,
+install-stack aborts rather than declaring success while the operator is
+about to be locked out.
 
 ## Detailed: each script
 
@@ -111,6 +122,19 @@ prior version) so sshd is never left broken. On success, ssh is
 This script never touches `/etc/ssh/sshd_config`. That file is
 package-managed; apt rewrites it on upgrades. The drop-in directory is
 the supported extension point.
+
+**Socket activation (Ubuntu 24.04).** Ubuntu 24.04 ships
+socket-activated SSH by default: `ssh.socket` binds the **default** port
+and spawns sshd on demand — regardless of the `Port` directive in the
+config chain. If you set a non-standard port via a drop-in, the socket
+still owns the default port while nothing listens on your configured
+port. A default-deny firewall that opens only the configured port then
+blocks the socket port → lockout. To prevent this, harden-ssh disables
+`ssh.socket` and enables standalone `ssh.service`, which reads the config
+chain and binds the configured port. This runs on **every** invocation
+(idempotent), so a package upgrade that re-enables the socket is caught
+on re-run. Because of this, install-stack runs harden-ssh **before**
+harden-firewall.
 
 ### harden-apache.sh
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -98,7 +98,7 @@ This goes straight to the CloudPanel mirror. Same packages (byte-equivalent, sig
 
 ## Stage table
 
-The installer runs in stages. You'll see `stage N/14:` in the log as it goes.
+The installer runs in stages. You'll see `stage N/15:` in the log as it goes.
 
 | Stage | What it does                                       |
 |-------|----------------------------------------------------|
@@ -110,14 +110,24 @@ The installer runs in stages. You'll see `stage N/14:` in the log as it goes.
 | 6     | certbot (Let's Encrypt + auto-renewal)             |
 | 7     | redis (localhost, requirepass, RAM-tiered)         |
 | 8     | memcached (localhost, UDP off)                     |
-| 9     | ufw firewall                                       |
-| 10    | fail2ban                                           |
-| 11    | unattended-upgrades                                |
-| 12    | sshd hardening                                     |
+| 9     | sshd hardening (disable ssh.socket, standalone sshd on configured port) |
+| 10    | ufw firewall                                       |
+| 11    | fail2ban                                           |
+| 12    | unattended-upgrades                                |
 | 13    | Apache hardening                                   |
 | 14    | php.ini hardening (per version)                    |
+| 15    | litesoup SSH user + sudo (only with `--ssh-key`)   |
 
-With `--skip-hardening`, stages 9 through 14 are skipped and the installer reports 8 stages total instead of 14.
+After the hardening stages, install-stack runs a **post-install SSH access
+check** (`verify_ssh_access`) that confirms sshd is listening on the
+configured port, UFW allows it, and `ssh.socket` is disabled — aborting
+rather than declaring success if the operator is about to be locked out.
+This is why sshd hardening (stage 9) runs **before** the firewall (stage
+10): on Ubuntu 24.04, socket-activated SSH binds the default port
+regardless of the `Port` directive, so the firewall must open the port
+standalone sshd actually listens on.
+
+With `--skip-hardening`, stages 9 through 15 are skipped and the installer reports 8 stages total instead of 15.
 
 ## After install
 

--- a/harden/harden-ssh.sh
+++ b/harden/harden-ssh.sh
@@ -44,6 +44,11 @@ Opt-in extras (only added when the matching flag is passed):
   PermitRootLogin no          # requires --no-root-login
 
 Behavior:
+  0. Disable Ubuntu 24.04 socket-activated SSH (ssh.socket) and switch to
+     standalone sshd, which binds the CONFIG port. Runs on every invocation
+     (idempotent) so a package upgrade that re-enables the socket is caught
+     on re-run. This MUST happen before harden-firewall.sh so the port the
+     firewall opens is the one sshd actually listens on.
   1. Render desired sshd hardening directives based on flags.
   2. Write them to /etc/ssh/sshd_config.d/52-litesoup-harden.conf
      (mode 0644 root:root) only when content differs. The 52- prefix
@@ -119,6 +124,53 @@ main() {
   if [ "${DRY_RUN}" != "1" ] && [ ! -d "${override_dir}" ]; then
     log_error "harden-ssh: ${override_dir} missing — is openssh-server installed?"
     exit 1
+  fi
+
+  # Determine the effective SSH port ONCE, up front. Used by the socket-
+  # activation check below and the post-reload health check. The port we are
+  # actually connected on is the strongest signal; otherwise fall back to the
+  # effective configured port (`sshd -T` resolves the full include chain).
+  local ssh_port=22
+  if [ -n "${SSH_CONNECTION:-}" ]; then
+    ssh_port="$(echo "${SSH_CONNECTION}" | awk '{print $4}')"
+  else
+    ssh_port="$(sshd -T 2>/dev/null | sed -n 's/^port //p' | tail -1)"
+    ssh_port="${ssh_port:-22}"
+  fi
+
+  # 0. SOCKET ACTIVATION CHECK (issue #58, #75). Ubuntu 24.04 ships
+  #    socket-activated SSH by default: `ssh.socket` binds the DEFAULT port and
+  #    spawns sshd on demand — regardless of the `Port` directive in the sshd
+  #    config chain. If a non-standard port is configured via a drop-in, the
+  #    socket still owns the default port while nothing listens on the config
+  #    port. A default-deny firewall (harden-firewall.sh) then opens the config
+  #    port and blocks the socket port → operator is locked out.
+  #
+  #    Fix: switch to traditional standalone sshd (ssh.service), which reads the
+  #    config chain and binds the CONFIG port. This MUST run before any reload /
+  #    health-check and before harden-firewall.sh, so the port the firewall opens
+  #    is the one sshd actually listens on.
+  #
+  #    This runs on EVERY invocation (not just when the override changed), so a
+  #    package upgrade that re-enables the socket is caught on re-run. It is
+  #    idempotent: once the socket is disabled it stays disabled.
+  if [ "${DRY_RUN}" != "1" ]; then
+    if systemctl is-active ssh.socket >/dev/null 2>&1; then
+      log_warn "harden-ssh: ssh.socket is active (Ubuntu 24.04 socket-activated SSH)"
+      log_warn "harden-ssh:    it binds the default port regardless of the Port directive."
+      log_info "harden-ssh: switching to traditional standalone sshd (port ${ssh_port})..."
+      systemctl disable --now ssh.socket 2>/dev/null || true
+      systemctl enable --now ssh.service 2>/dev/null || true
+      # Give sshd a moment to bind the config port.
+      if ! ss -tlnp 2>/dev/null | grep -qE ":${ssh_port}\\b.*sshd"; then
+        sleep 2
+      fi
+      if ss -tlnp 2>/dev/null | grep -qE ":${ssh_port}\\b.*sshd"; then
+        log_info "harden-ssh: sshd now owns port ${ssh_port} directly"
+      else
+        log_warn "harden-ssh: could not verify sshd owns port ${ssh_port} directly"
+      fi
+    fi
   fi
 
   # 1. Render desired override content. Heredoc gives us REAL newlines; using
@@ -222,15 +274,6 @@ EOF
     #     log a warning and proceed — the override IS written and will take
     #     effect on next sshd restart. Only revert if sshd died completely.
     if [ "${DRY_RUN}" != "1" ]; then
-      local ssh_port=22
-      if [ -n "${SSH_CONNECTION:-}" ]; then
-        # Port we are actually connected on — best signal.
-        ssh_port="$(echo "${SSH_CONNECTION}" | awk '{print $4}')"
-      else
-        # Fallback: read the effective configured port.
-        ssh_port="$(sshd -T 2>/dev/null | sed -n 's/^port //p' | tail -1)"
-        ssh_port="${ssh_port:-22}"
-      fi
       local poll_ok=0
       local i
       for i in 1 2 3 4 5 6; do
@@ -266,33 +309,6 @@ EOF
       fi
       # Reload succeeded (or process alive but slow) — discard backup.
       [ -n "${backup:-}" ] && rm -f "${backup}"
-
-      # 5c. SOCKET ACTIVATION CHECK (issue #58). Ubuntu 24.04 ships
-      #     socket-activated SSH by default. When systemctl daemon-reload
-      #     runs (e.g. from litesoup backup configure), systemd can silently
-      #     deactivate the socket unit. Fix: switch to standalone sshd.
-      if systemctl is-active ssh.socket >/dev/null 2>&1; then
-        log_warn "harden-ssh: ssh.socket is active (Ubuntu 24.04 socket-activated SSH)"
-        log_warn "harden-ssh:    a later daemon-reload can silently kill port 22."
-        log_info "harden-ssh: switching to traditional standalone sshd..."
-        if [ "${DRY_RUN}" = "1" ]; then
-          log_info "[DRYRUN] would run: systemctl disable --now ssh.socket"
-          log_info "[DRYRUN] would run: systemctl enable --now ssh.service"
-        else
-          systemctl disable --now ssh.socket 2>/dev/null || true
-          systemctl enable --now ssh.service 2>/dev/null || true
-          if ss -tlnp 2>/dev/null | grep -qE ":${ssh_port}\b.*sshd"; then
-            log_info "harden-ssh: sshd now owns port ${ssh_port} directly"
-          else
-            sleep 2
-            if ss -tlnp 2>/dev/null | grep -qE ":${ssh_port}\b.*sshd"; then
-              log_info "harden-ssh: sshd now owns port ${ssh_port} directly"
-            else
-              log_warn "harden-ssh: could not verify sshd owns port directly"
-            fi
-          fi
-        fi
-      fi
     fi
   else
     log_info "harden-ssh: no override changes — skipping reload"

--- a/install/install-stack.sh
+++ b/install/install-stack.sh
@@ -43,8 +43,9 @@ Options:
   --redis-maxmemory=SIZE      Override Redis maxmemory (e.g. 256mb, 1gb).
                               Default: auto from system RAM tier
                               (<2G→128mb, 2–8G→512mb, ≥8G→2gb).
-  --skip-hardening            Skip stages 9-11 (firewall, fail2ban,
-                              unattended-upgrades). Use for dev VMs or
+  --skip-hardening            Skip all hardening stages (harden-ssh,
+                              harden-firewall, fail2ban, unattended-upgrades,
+                              harden-apache, harden-php). Use for dev VMs or
                               when host-managed elsewhere.
   --dry-run                   Print actions without executing
   --help                      Show this help
@@ -59,6 +60,61 @@ Installs: Apache (mpm_event + http2), one PHP-FPM pool per requested version
           /home/litesoup/webapps/ with a per-user pool at
           PHP_VERSION_DEFAULT (8.2).
 EOF
+}
+
+# verify_ssh_access — post-hardening safety net (issue #75).
+# Confirms the operator will NOT be locked out before install-stack declares
+# success: sshd is listening on the configured port, UFW allows it, and
+# socket-activated SSH is disabled. Called at the end of the hardening stages.
+#
+# The port that matters for ongoing access is the CONFIG port (`sshd -T`),
+# because after harden-ssh disables the socket, standalone sshd binds the
+# configured port and harden-firewall opens that same port. The operator's
+# ORIGINAL connection port may differ from the config port (that is the whole
+# socket-activation bug), so we must NOT trust SSH_CONNECTION here.
+verify_ssh_access() {
+  if [ "${DRY_RUN}" = "1" ]; then
+    log_info "[dry-run] would verify SSH reachability on the configured port"
+    return 0
+  fi
+
+  local ssh_port
+  ssh_port="$(sshd -T 2>/dev/null | sed -n 's/^port //p' | tail -1)"
+  ssh_port="${ssh_port:-22}"
+
+  local problems=0
+
+  # 1. sshd must be listening on the configured port.
+  if ! ss -tlnp 2>/dev/null | grep -qE ":${ssh_port}\\b.*sshd"; then
+    log_error "verify-ssh: sshd is NOT listening on configured port ${ssh_port}"
+    problems=1
+  else
+    log_info "verify-ssh: sshd listening on configured port ${ssh_port}"
+  fi
+
+  # 2. Socket-activated SSH must be disabled (else it owns a different port).
+  if systemctl is-active ssh.socket >/dev/null 2>&1; then
+    log_error "verify-ssh: ssh.socket is STILL active — it binds the default port regardless of the Port directive"
+    problems=1
+  fi
+
+  # 3. UFW (if active) must allow the configured port.
+  if command -v ufw >/dev/null 2>&1 \
+      && ufw status 2>/dev/null | grep -q '^Status:[[:space:]]active'; then
+    if ! ufw status 2>/dev/null | grep -qE "(^|[[:space:]])${ssh_port}/tcp([[:space:]]|$)"; then
+      log_error "verify-ssh: UFW is active but does NOT allow ${ssh_port}/tcp"
+      problems=1
+    else
+      log_info "verify-ssh: UFW allows ${ssh_port}/tcp"
+    fi
+  fi
+
+  if [ "${problems}" = "1" ]; then
+    log_error "verify-ssh: SSH access check FAILED — refusing to declare install complete."
+    log_error "verify-ssh: Do NOT disconnect from this session. Investigate before rebooting."
+    exit 1
+  fi
+  log_info "verify-ssh: SSH access confirmed on configured port ${ssh_port}"
 }
 
 main() {
@@ -125,10 +181,12 @@ main() {
   require_root
   require_ubuntu_2404
 
-  # Stage count: without --skip-hardening, hardening/stages 11-16 run (harden-ssh.sh
-  # is NOT included — it's a post-install step, run `bash harden/harden-ssh.sh`
-  # manually when ready). With --skip-hardening, stages 9-11 run.
-  local total_stages=17
+  # Stage count: without --skip-hardening, hardening stages 11-17 run, including
+  # harden-ssh.sh (which disables Ubuntu 24.04 socket-activated SSH and switches
+  # to standalone sshd on the configured port) BEFORE harden-firewall.sh, so the
+  # firewall opens the port sshd actually listens on (issue #75). With
+  # --skip-hardening, stages 9-11 run.
+  local total_stages=18
   [ "${skip_hardening}" = "1" ] && total_stages=11
 
   log_info "stage 1/${total_stages}: apache"
@@ -206,31 +264,40 @@ main() {
     # ordering consistent with traditional sysadmin practice.
     local harden_dir="${SCRIPT_DIR}/../harden"
 
-    log_info "stage 11/${total_stages}: harden-firewall (ufw)"
+    # harden-ssh MUST run before harden-firewall (issue #75). On Ubuntu 24.04
+    # SSH is socket-activated by default: ssh.socket binds the DEFAULT port
+    # regardless of the Port directive, so opening the configured port in UFW
+    # while the socket still owns a different port locks the operator out.
+    # harden-ssh.sh disables the socket and switches to standalone sshd on the
+    # configured port; only then does harden-firewall open that same port.
+    log_info "stage 11/${total_stages}: harden-ssh (disable ssh.socket, standalone sshd on configured port)"
+    run_or_dryrun bash "${harden_dir}/harden-ssh.sh"
+
+    log_info "stage 12/${total_stages}: harden-firewall (ufw)"
     run_or_dryrun bash "${harden_dir}/harden-firewall.sh"
 
-  log_info "stage 12/${total_stages}: harden-fail2ban"
-  run_or_dryrun bash "${harden_dir}/harden-fail2ban.sh"
+    log_info "stage 13/${total_stages}: harden-fail2ban"
+    run_or_dryrun bash "${harden_dir}/harden-fail2ban.sh"
 
-  log_info "stage 13/${total_stages}: harden-unattended-upgrades"
-  run_or_dryrun bash "${harden_dir}/harden-unattended-upgrades.sh"
+    log_info "stage 14/${total_stages}: harden-unattended-upgrades"
+    run_or_dryrun bash "${harden_dir}/harden-unattended-upgrades.sh"
 
-  # NOTE: harden-ssh.sh is NOT called during install-stack. It's available as
-  # a post-install step: run `bash /usr/lib/litesoup/harden/harden-ssh.sh`
-  # when ready. This avoids any risk of SSH lockout during initial provisioning.
-  # See harden/harden-ssh.sh for options (--no-root-login, --no-password-auth).
+    log_info "stage 15/${total_stages}: harden-apache (ServerTokens, headers, mod_status local-only)"
+    run_or_dryrun bash "${harden_dir}/harden-apache.sh"
 
-  log_info "stage 14/${total_stages}: harden-apache (ServerTokens, headers, mod_status local-only)"
-  run_or_dryrun bash "${harden_dir}/harden-apache.sh"
+    log_info "stage 16/${total_stages}: harden-php (php.ini hardening per version)"
+    run_or_dryrun bash "${harden_dir}/harden-php.sh"
 
-  log_info "stage 15/${total_stages}: harden-php (php.ini hardening per version)"
-  run_or_dryrun bash "${harden_dir}/harden-php.sh"
+    log_info "stage 17/${total_stages}: harden-user (litesoup SSH user + sudo)"
+    # Only runs if --ssh-key was passed; otherwise it's a no-op.
+    if [ -n "${SSH_KEY:-}" ]; then
+      run_or_dryrun bash "${harden_dir}/harden-user.sh" --ssh-key="${SSH_KEY}"
+    fi
 
-  log_info "stage 16/${total_stages}: harden-user (litesoup SSH user + sudo)"
-  # Only runs if --ssh-key was passed; otherwise it's a no-op.
-  if [ -n "${SSH_KEY:-}" ]; then
-    run_or_dryrun bash "${harden_dir}/harden-user.sh" --ssh-key="${SSH_KEY}"
-  fi
+    # Post-hardening SSH access verification (issue #75). Confirms sshd is
+    # actually listening on the configured port and UFW allows it, so we never
+    # declare the install complete while the operator is about to be locked out.
+    verify_ssh_access
 
   fi  # end of skip_hardening else block
 

--- a/test/bats/unit_harden.bats
+++ b/test/bats/unit_harden.bats
@@ -318,3 +318,51 @@ EOF
   run -0 bash "${REPO_ROOT}/install/install-stack.sh" --help
   [[ "${output}" == *"--skip-hardening"* ]]
 }
+
+# --- issue #75: socket-activation hardening must run during install-stack ---
+
+@test "harden-ssh disables ssh.socket (issue #75)" {
+  # Ubuntu 24.04 socket-activated SSH binds the default port regardless of the
+  # Port directive. harden-ssh must switch to standalone sshd or a default-deny
+  # firewall opens the config port while the socket owns a different one.
+  grep -q 'systemctl disable --now ssh.socket' "${REPO_ROOT}/harden/harden-ssh.sh"
+}
+
+@test "harden-ssh socket check runs BEFORE reload (outside the CHANGED gate)" {
+  # The socket-disable must not be gated behind `if [ "${CHANGED}" = "1" ]` —
+  # it must run on every invocation so a package upgrade that re-enables the
+  # socket is caught on re-run. Structurally: the socket-disable line must come
+  # before the `systemctl reload ssh` line (reload is what sits inside the
+  # CHANGED gate).
+  local sock_line reload_line
+  sock_line="$(grep -n 'systemctl disable --now ssh.socket' "${REPO_ROOT}/harden/harden-ssh.sh" | head -1 | cut -d: -f1)"
+  reload_line="$(grep -n 'systemctl reload ssh' "${REPO_ROOT}/harden/harden-ssh.sh" | head -1 | cut -d: -f1)"
+  [ -n "${sock_line}" ] && [ -n "${reload_line}" ]
+  [ "${sock_line}" -lt "${reload_line}" ]
+}
+
+@test "harden-ssh socket check resolves the configured port via sshd -T" {
+  # Standalone sshd binds the CONFIG port, which is what the firewall opens.
+  grep -q 'sshd -T' "${REPO_ROOT}/harden/harden-ssh.sh"
+}
+
+@test "install-stack calls harden-ssh BEFORE harden-firewall (issue #75)" {
+  # Ordering is the whole fix: harden-ssh disables the socket and switches to
+  # standalone sshd on the configured port; only then does harden-firewall open
+  # that same port. If harden-firewall runs first it opens the config port while
+  # the socket still owns a different one → lockout.
+  local ssh_line fw_line
+  ssh_line="$(grep -n 'harden-ssh.sh' "${REPO_ROOT}/install/install-stack.sh" | head -1 | cut -d: -f1)"
+  fw_line="$(grep -n 'harden-firewall.sh' "${REPO_ROOT}/install/install-stack.sh" | head -1 | cut -d: -f1)"
+  [ -n "${ssh_line}" ] && [ -n "${fw_line}" ]
+  [ "${ssh_line}" -lt "${fw_line}" ]
+}
+
+@test "install-stack includes post-hardening SSH access verification (issue #75)" {
+  grep -q 'verify_ssh_access' "${REPO_ROOT}/install/install-stack.sh"
+}
+
+@test "install-stack --help mentions harden-ssh" {
+  run -0 bash "${REPO_ROOT}/install/install-stack.sh" --help
+  [[ "${output}" == *"harden-ssh"* ]]
+}


### PR DESCRIPTION
Closes #75

## Problem
On Ubuntu 24.04, SSH is **socket-activated** by default: `ssh.socket` binds the **default** port and spawns sshd on demand — regardless of the `Port` directive in the sshd config chain. `install-stack.sh` ran `harden-firewall.sh` (which opens the configured port, then enables default-deny) **without** first disabling the socket. With a non-standard port set via a drop-in, the firewall opened the configured port (where nothing listened) while blocking the socket port (where sshd actually listened) → **operator locked out**, console recovery required.

## Fix
1. **`install-stack.sh` now runs `harden-ssh.sh` as the first hardening stage, before `harden-firewall.sh`.** harden-ssh disables `ssh.socket` and switches to standalone `ssh.service`, which binds the configured port — so the firewall opens the port sshd actually listens on.
2. **`harden-ssh.sh` disables `ssh.socket` on every run** (moved out of the `CHANGED` gate, before reload). Idempotent, and catches a package upgrade that re-enables the socket on re-run.
3. **Post-install SSH access verification** — after hardening, `install-stack.sh` runs `verify_ssh_access`: confirms sshd is listening on the configured port, UFW allows it, and `ssh.socket` is disabled. Aborts (rather than declaring success) if the operator is about to be locked out.

## Tests
Added 6 unit tests (ordering, socket-disable placement, verify presence, help text). Full suite: **158 pass / 0 fail**.

## Docs
Updated `docs/hardening.md`, `docs/architecture.md`, `docs/install.md`, and `CHANGELOG.md`.