### PR TITLE
fix: mask ssh.socket + boot-time guard so SSH lockout fix survives reboot (closes #75 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed (issue #75 follow-up)
+
+- **SSH lockout fix now survives a reboot** — the v0.10.9 fix used
+  `systemctl disable --now ssh.socket`, but `disable` only removes the
+  wants-symlinks; a reboot or `unattended-upgrades` kernel update re-enables
+  the socket, re-breaking SSH on a non-standard port. `harden-ssh.sh` now
+  **masks** `ssh.socket` (symlinks it to `/dev/null`), so no package script
+  or reboot can re-enable it.
+- **Boot-time guard** — harden-ssh installs a systemd oneshot
+  (`litesoup-ssh-guard.service`) that runs at every boot to re-mask
+  `ssh.socket`, ensure standalone `ssh.service` is running, and assert sshd
+  is listening on the configured port, so the lockout cannot silently recur.
+  (`harden/harden-ssh.sh`, `harden/ssh-guard.sh`)
+- **`verify_ssh_access` now asserts the masked state** — it flags an
+  enabled-but-inactive socket (the exact pre-reboot state that caused the
+  lockout), not just an active one. (`install/install-stack.sh`,
+  `test/bats/unit_harden.bats`)
+
 ## [0.10.9] - 2026-08-21
 
 ### Fixed (issue #75)

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -129,12 +129,21 @@ and spawns sshd on demand — regardless of the `Port` directive in the
 config chain. If you set a non-standard port via a drop-in, the socket
 still owns the default port while nothing listens on your configured
 port. A default-deny firewall that opens only the configured port then
-blocks the socket port → lockout. To prevent this, harden-ssh disables
-`ssh.socket` and enables standalone `ssh.service`, which reads the config
-chain and binds the configured port. This runs on **every** invocation
-(idempotent), so a package upgrade that re-enables the socket is caught
-on re-run. Because of this, install-stack runs harden-ssh **before**
-harden-firewall.
+blocks the socket port → lockout. To prevent this, harden-ssh **masks**
+`ssh.socket` (symlinks it to `/dev/null`, so no package script or reboot
+can re-enable it) and enables standalone `ssh.service`, which reads the
+config chain and binds the configured port. This runs on **every**
+invocation (idempotent), so a package upgrade that re-enables the socket
+is caught on re-run. Because of this, install-stack runs harden-ssh
+**before** harden-firewall.
+
+**Boot-time guard (survives reboot).** `disable` alone is not enough — a
+reboot or `unattended-upgrades` kernel update can re-enable `ssh.socket`,
+re-breaking SSH exactly as before. harden-ssh therefore installs a
+systemd oneshot, `litesoup-ssh-guard.service`, that runs at **every boot**
+to re-mask `ssh.socket`, ensure standalone `ssh.service` is running, and
+assert sshd is listening on the configured port. The lockout cannot
+silently recur.
 
 ### harden-apache.sh
 

--- a/harden/harden-ssh.sh
+++ b/harden/harden-ssh.sh
@@ -44,11 +44,14 @@ Opt-in extras (only added when the matching flag is passed):
   PermitRootLogin no          # requires --no-root-login
 
 Behavior:
-  0. Disable Ubuntu 24.04 socket-activated SSH (ssh.socket) and switch to
-     standalone sshd, which binds the CONFIG port. Runs on every invocation
-     (idempotent) so a package upgrade that re-enables the socket is caught
-     on re-run. This MUST happen before harden-firewall.sh so the port the
-     firewall opens is the one sshd actually listens on.
+  0. MASK Ubuntu 24.04 socket-activated SSH (ssh.socket) and switch to
+     standalone sshd, which binds the CONFIG port. Masking (not just
+     disabling) makes it impossible for a package upgrade or reboot to
+     re-enable the socket. Also installs a boot-time systemd guard
+     (litesoup-ssh-guard.service) that re-asserts the mask + standalone
+     sshd at every boot, so the lockout cannot silently recur. Runs on
+     every invocation (idempotent). MUST happen before harden-firewall.sh
+     so the port the firewall opens is the one sshd actually listens on.
   1. Render desired sshd hardening directives based on flags.
   2. Write them to /etc/ssh/sshd_config.d/52-litesoup-harden.conf
      (mode 0644 root:root) only when content differs. The 52- prefix
@@ -101,6 +104,47 @@ write_override_if_changed() {
   fi
 }
 
+# install_ssh_guard — install the boot-time SSH guard (issue #75 follow-up).
+# Copies harden/ssh-guard.sh to the installed lib dir and wires up a systemd
+# oneshot (litesoup-ssh-guard.service) that runs at every boot to re-mask
+# ssh.socket and assert sshd is listening on the configured port. This is what
+# makes the socket-activation lockout non-recurring: even if a package upgrade
+# recreates ssh.socket, the guard re-masks it on the next boot.
+install_ssh_guard() {
+  local guard_src="${SCRIPT_DIR}/ssh-guard.sh"
+  local guard_dst="/usr/lib/litesoup/harden/ssh-guard.sh"
+  local unit="/etc/systemd/system/litesoup-ssh-guard.service"
+
+  # Copy the guard script to the installed lib dir (idempotent). When running
+  # from the installed location, src == dst and the copy is skipped.
+  if [ -f "${guard_src}" ] && [ "${guard_src}" != "${guard_dst}" ]; then
+    install -d -m 0755 "$(dirname "${guard_dst}")"
+    install -m 0755 "${guard_src}" "${guard_dst}"
+  elif [ ! -f "${guard_dst}" ]; then
+    log_warn "harden-ssh: ssh-guard.sh not found (${guard_src}) — skipping boot-time guard"
+    return 0
+  fi
+
+  cat > "${unit}" <<UNITEOF
+[Unit]
+Description=LiteSoup SSH boot guard — mask ssh.socket, assert sshd on configured port
+After=network.target ssh.service
+ConditionPathExists=/etc/ssh/sshd_config
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=${guard_dst}
+
+[Install]
+WantedBy=multi-user.target
+UNITEOF
+
+  systemctl daemon-reload
+  systemctl enable litesoup-ssh-guard.service >/dev/null 2>&1 || true
+  log_info "harden-ssh: boot-time SSH guard installed (${unit})"
+}
+
 main() {
   local arg
   for arg in "$@"; do
@@ -146,31 +190,45 @@ main() {
   #    port. A default-deny firewall (harden-firewall.sh) then opens the config
   #    port and blocks the socket port → operator is locked out.
   #
-  #    Fix: switch to traditional standalone sshd (ssh.service), which reads the
-  #    config chain and binds the CONFIG port. This MUST run before any reload /
-  #    health-check and before harden-firewall.sh, so the port the firewall opens
-  #    is the one sshd actually listens on.
+  #    Fix: MASK ssh.socket (not just disable) and switch to traditional
+  #    standalone sshd (ssh.service), which reads the config chain and binds the
+  #    CONFIG port. Masking symlinks the unit to /dev/null so NO package script
+  #    or reboot can re-enable it. This MUST run before any reload / health-check
+  #    and before harden-firewall.sh, so the port the firewall opens is the one
+  #    sshd actually listens on.
   #
-  #    This runs on EVERY invocation (not just when the override changed), so a
-  #    package upgrade that re-enables the socket is caught on re-run. It is
-  #    idempotent: once the socket is disabled it stays disabled.
+  #    Check `is-enabled` (not just `is-active`): after a reboot the socket is
+  #    ENABLED but inactive until a connection arrives, so an `is-active` test
+  #    alone would miss it. Runs on EVERY invocation; masking is idempotent.
   if [ "${DRY_RUN}" != "1" ]; then
-    if systemctl is-active ssh.socket >/dev/null 2>&1; then
-      log_warn "harden-ssh: ssh.socket is active (Ubuntu 24.04 socket-activated SSH)"
+    local sock_state
+    sock_state="$(systemctl is-enabled ssh.socket 2>/dev/null || echo unknown)"
+    if [ "${sock_state}" != "masked" ]; then
+      log_warn "harden-ssh: ssh.socket is '${sock_state}' (Ubuntu 24.04 socket-activated SSH)"
       log_warn "harden-ssh:    it binds the default port regardless of the Port directive."
-      log_info "harden-ssh: switching to traditional standalone sshd (port ${ssh_port})..."
-      systemctl disable --now ssh.socket 2>/dev/null || true
+      log_info "harden-ssh: masking ssh.socket and switching to standalone sshd (port ${ssh_port})..."
+      systemctl mask --now ssh.socket 2>/dev/null || true
       systemctl enable --now ssh.service 2>/dev/null || true
       # Give sshd a moment to bind the config port.
-      if ! ss -tlnp 2>/dev/null | grep -qE ":${ssh_port}\\b.*sshd"; then
+      if ! ss -tlnp 2>/dev/null | grep -qE ":${ssh_port}\b.*sshd"; then
         sleep 2
       fi
-      if ss -tlnp 2>/dev/null | grep -qE ":${ssh_port}\\b.*sshd"; then
+      if ss -tlnp 2>/dev/null | grep -qE ":${ssh_port}\b.*sshd"; then
         log_info "harden-ssh: sshd now owns port ${ssh_port} directly"
       else
         log_warn "harden-ssh: could not verify sshd owns port ${ssh_port} directly"
       fi
     fi
+  fi
+
+  # 0b. BOOT-TIME GUARD (issue #75 follow-up). `mask` survives reboot, but a
+  #     package upgrade could theoretically recreate the socket. Install a
+  #     systemd oneshot (litesoup-ssh-guard.service) that re-asserts the mask +
+  #     standalone sshd at every boot, so the lockout cannot silently recur.
+  if [ "${DRY_RUN}" != "1" ]; then
+    install_ssh_guard
+  else
+    log_info "[DRYRUN] would install litesoup-ssh-guard.service + /usr/lib/litesoup/harden/ssh-guard.sh"
   fi
 
   # 1. Render desired override content. Heredoc gives us REAL newlines; using

--- a/harden/ssh-guard.sh
+++ b/harden/ssh-guard.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# harden/ssh-guard.sh — boot-time SSH guard (issue #75 follow-up).
+#
+# Runs as a systemd oneshot (litesoup-ssh-guard.service) at every boot.
+# Prevents the Ubuntu 24.04 socket-activation SSH lockout from silently
+# recurring after a reboot or package upgrade:
+#
+#   1. MASK ssh.socket — unlike `disable`, masking symlinks the unit to
+#      /dev/null so NO package script or reboot can re-enable it.
+#   2. Ensure standalone ssh.service is enabled and running (it binds the
+#      CONFIGURED port, not the default socket port).
+#   3. Assert sshd is actually listening on the configured port; if not,
+#      restart ssh and re-check.
+#
+# Idempotent and safe to run at any time. Best-effort: logs clearly but
+# never blocks boot (a failed oneshot does not halt the machine).
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../install/lib/common.sh
+source "${SCRIPT_DIR}/../install/lib/common.sh"
+
+main() {
+  # 1. Mask ssh.socket (prevents ANY re-enable, incl. package scripts/reboot).
+  if [ -L /etc/systemd/system/ssh.socket ] \
+      && [ "$(readlink /etc/systemd/system/ssh.socket)" = "/dev/null" ]; then
+    log_info "ssh-guard: ssh.socket already masked"
+  else
+    log_info "ssh-guard: masking ssh.socket"
+    systemctl mask --now ssh.socket 2>/dev/null || true
+  fi
+
+  # 2. Ensure standalone sshd is enabled + running.
+  systemctl enable ssh.service 2>/dev/null || true
+  if ! systemctl is-active --quiet ssh.service; then
+    log_info "ssh-guard: starting ssh.service"
+    systemctl start ssh.service 2>/dev/null || true
+  fi
+
+  # 3. Assert sshd is listening on the configured port.
+  local ssh_port
+  ssh_port="$(sshd -T 2>/dev/null | sed -n 's/^port //p' | tail -1)" || true
+  ssh_port="${ssh_port:-22}"
+
+  if ss -tlnp 2>/dev/null | grep -qE ":${ssh_port}\\b.*sshd"; then
+    log_info "ssh-guard: sshd listening on configured port ${ssh_port}"
+    return 0
+  fi
+
+  log_warn "ssh-guard: sshd NOT listening on configured port ${ssh_port} — restarting ssh"
+  systemctl restart ssh 2>/dev/null || true
+  sleep 2
+  if ss -tlnp 2>/dev/null | grep -qE ":${ssh_port}\\b.*sshd"; then
+    log_info "ssh-guard: sshd listening on port ${ssh_port} after restart"
+  else
+    log_error "ssh-guard: FAILED to bring sshd up on port ${ssh_port} — investigate"
+  fi
+}
+
+main "$@"

--- a/install/install-stack.sh
+++ b/install/install-stack.sh
@@ -92,9 +92,16 @@ verify_ssh_access() {
     log_info "verify-ssh: sshd listening on configured port ${ssh_port}"
   fi
 
-  # 2. Socket-activated SSH must be disabled (else it owns a different port).
+  # 2. Socket-activated SSH must be MASKED (not just inactive). Masking
+  #    prevents a reboot/package upgrade from re-enabling it. An enabled-but-
+  #    inactive socket is exactly the pre-reboot state that caused the lockout.
+  local sock_state
+  sock_state="$(systemctl is-enabled ssh.socket 2>/dev/null || echo unknown)"
   if systemctl is-active ssh.socket >/dev/null 2>&1; then
-    log_error "verify-ssh: ssh.socket is STILL active — it binds the default port regardless of the Port directive"
+    log_error "verify-ssh: ssh.socket is ACTIVE — it binds the default port regardless of the Port directive"
+    problems=1
+  elif [ "${sock_state}" != "masked" ]; then
+    log_error "verify-ssh: ssh.socket is '${sock_state}' (not masked) — a reboot/package upgrade could re-enable it"
     problems=1
   fi
 

--- a/test/bats/unit_harden.bats
+++ b/test/bats/unit_harden.bats
@@ -321,21 +321,29 @@ EOF
 
 # --- issue #75: socket-activation hardening must run during install-stack ---
 
-@test "harden-ssh disables ssh.socket (issue #75)" {
+@test "harden-ssh MASKS ssh.socket (issue #75 follow-up)" {
   # Ubuntu 24.04 socket-activated SSH binds the default port regardless of the
-  # Port directive. harden-ssh must switch to standalone sshd or a default-deny
-  # firewall opens the config port while the socket owns a different one.
-  grep -q 'systemctl disable --now ssh.socket' "${REPO_ROOT}/harden/harden-ssh.sh"
+  # Port directive. harden-ssh must MASK ssh.socket (not just disable) and
+  # switch to standalone sshd, or a default-deny firewall opens the config port
+  # while the socket owns a different one → lockout. Masking (vs disable) is
+  # what survives a reboot / package upgrade.
+  grep -q 'systemctl mask --now ssh.socket' "${REPO_ROOT}/harden/harden-ssh.sh"
+}
+
+@test "harden-ssh no longer uses disable --now for ssh.socket" {
+  # disable only removes the wants-symlinks — a reboot/package upgrade can
+  # re-enable the socket, which is exactly the recurrence the follow-up fixes.
+  ! grep -q 'systemctl disable --now ssh.socket' "${REPO_ROOT}/harden/harden-ssh.sh"
 }
 
 @test "harden-ssh socket check runs BEFORE reload (outside the CHANGED gate)" {
-  # The socket-disable must not be gated behind `if [ "${CHANGED}" = "1" ]` —
-  # it must run on every invocation so a package upgrade that re-enables the
-  # socket is caught on re-run. Structurally: the socket-disable line must come
+  # The socket-mask must not be gated behind `if [ "${CHANGED}" = "1" ]` — it
+  # must run on every invocation so a package upgrade that re-enables the
+  # socket is caught on re-run. Structurally: the socket-mask line must come
   # before the `systemctl reload ssh` line (reload is what sits inside the
   # CHANGED gate).
   local sock_line reload_line
-  sock_line="$(grep -n 'systemctl disable --now ssh.socket' "${REPO_ROOT}/harden/harden-ssh.sh" | head -1 | cut -d: -f1)"
+  sock_line="$(grep -n 'systemctl mask --now ssh.socket' "${REPO_ROOT}/harden/harden-ssh.sh" | head -1 | cut -d: -f1)"
   reload_line="$(grep -n 'systemctl reload ssh' "${REPO_ROOT}/harden/harden-ssh.sh" | head -1 | cut -d: -f1)"
   [ -n "${sock_line}" ] && [ -n "${reload_line}" ]
   [ "${sock_line}" -lt "${reload_line}" ]
@@ -344,6 +352,25 @@ EOF
 @test "harden-ssh socket check resolves the configured port via sshd -T" {
   # Standalone sshd binds the CONFIG port, which is what the firewall opens.
   grep -q 'sshd -T' "${REPO_ROOT}/harden/harden-ssh.sh"
+}
+
+@test "harden-ssh installs a boot-time guard unit (issue #75 follow-up)" {
+  # The guard re-asserts the mask + standalone sshd at every boot so the
+  # lockout cannot silently recur after a reboot or package upgrade.
+  grep -q 'litesoup-ssh-guard.service' "${REPO_ROOT}/harden/harden-ssh.sh"
+  grep -q 'install_ssh_guard' "${REPO_ROOT}/harden/harden-ssh.sh"
+}
+
+@test "ssh-guard.sh exists and masks ssh.socket (issue #75 follow-up)" {
+  [ -f "${REPO_ROOT}/harden/ssh-guard.sh" ]
+  grep -q 'systemctl mask --now ssh.socket' "${REPO_ROOT}/harden/ssh-guard.sh"
+}
+
+@test "verify-ssh asserts ssh.socket is masked (issue #75 follow-up)" {
+  # verify_ssh_access must catch an enabled-but-inactive socket (the exact
+  # pre-reboot state that caused the lockout) by asserting the masked state.
+  grep -q 'is-enabled ssh.socket' "${REPO_ROOT}/install/install-stack.sh"
+  grep -q '"masked"' "${REPO_ROOT}/install/install-stack.sh"
 }
 
 @test "install-stack calls harden-ssh BEFORE harden-firewall (issue #75)" {


### PR DESCRIPTION
Addresses the follow-up on #75: the v0.10.9 fix does **not** survive a reboot.

## Problem
`harden-ssh.sh` used `systemctl disable --now ssh.socket`. `disable` only removes the wants-symlinks — a reboot or `unattended-upgrades` kernel update re-enables the socket, which re-breaks SSH on a non-standard port exactly as before (socket binds default port, UFW only allows the configured port → lockout).

## Fix
1. **`harden-ssh.sh` now MASKS `ssh.socket`** (`systemctl mask --now ssh.socket`) instead of `disable`. Masking symlinks the unit to `/dev/null`, so no package script or reboot can re-enable it. The check also uses `is-enabled` (not just `is-active`) so an enabled-but-inactive socket after reboot is caught.
2. **Boot-time guard** — harden-ssh installs a systemd oneshot `litesoup-ssh-guard.service` that runs at **every boot** to re-mask `ssh.socket`, ensure standalone `ssh.service` is running, and assert sshd is listening on the configured port. The lockout cannot silently recur.
3. **New `harden/ssh-guard.sh`** — the guard script (installed to `/usr/lib/litesoup/harden/`).
4. **`verify_ssh_access` now asserts the masked state** — flags an enabled-but-inactive socket (the exact pre-reboot state that caused the lockout), not just an active one.

## Tests
Full bats suite: **162 pass / 0 fail** (updated 2, added 4).