### PR TITLE
feat(backup): make zstd the default backup compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Backups now use zstd as the default compression** instead of gzip —
+  `database.sql.zst` (`wp db export - | zstd -8`) and `files.tar.zst`
+  (`tar cf - | zstd -1`). ~2x faster on SQL, ~12x faster on media with equal
+  or better ratios (benchmarked on sg10, 2026-08-29 — team-rd #17). Archives
+  are verified after creation (`zstd -t`, `CREATE TABLE` presence for DB).
+  `zstd` is installed during `install-stack.sh` (backup stage) and on-demand
+  by the backup/restore scripts. Restore/list handle the `.zst` format.
+  (`backup/lib/common.sh`, `backup/backup-site.sh`, `backup/backup-restore.sh`,
+  `backup/backup-list.sh`, `install/install-stack.sh`, `docs/backup.md`)
+
 ## [0.10.11] - 2026-08-25
 
 ### Fixed (issues #78, #79)

--- a/backup/backup-list.sh
+++ b/backup/backup-list.sh
@@ -75,8 +75,8 @@ main() {
       local size
       size="$(backup_size_human "${backup_base}/${dir}" 2>/dev/null || echo "?")"
       local contents=""
-      [ -f "${backup_base}/${dir}/database.sql" ] && contents="${contents} DB"
-      [ -f "${backup_base}/${dir}/files.tar.gz" ] && contents="${contents} files"
+      [ -f "${backup_base}/${dir}/database.sql.zst" ] && contents="${contents} DB"
+      [ -f "${backup_base}/${dir}/files.tar.zst" ] && contents="${contents} files"
       [ -z "${contents}" ] && contents=" (empty)"
       printf '  %-22s %10s  %s\n' "${dir}" "${size}" "${contents}"
     done

--- a/backup/backup-restore.sh
+++ b/backup/backup-restore.sh
@@ -84,6 +84,9 @@ main() {
   parse_args "$@"
   require_root
 
+  # Backups are zstd-compressed by default — ensure the binary is present.
+  backup_require_zstd
+
   if [ -z "${DOMAIN}" ]; then
     log_error "--domain is required"
     usage
@@ -135,7 +138,7 @@ main() {
 
   # 4. Restore files
   if [ "${SKIP_FILES}" != "1" ]; then
-    local archive="${restore_dir}/files.tar.gz"
+    local archive="${restore_dir}/files.tar.zst"
     if [ ! -f "${archive}" ]; then
       log_error "restore: file archive not found: ${archive}"
       log_error "restore: use --skip-files if restoring database only"
@@ -144,12 +147,12 @@ main() {
     log_info "restore: extracting files to ${docroot}..."
 
     if [ "${DRY_RUN}" = "1" ]; then
-      log_info "[DRYRUN] would tar -xzf ${archive} -C /"
+      log_info "[DRYRUN] would tar --zstd -xf ${archive} -C /"
       log_info "[DRYRUN] would chown -R ${SITE_USER}:${SITE_USER} ${docroot}"
     else
       # Archive was created with -C parent_dir basename, so extract from /
       # restores the full path: /home/<user>/webapps/<domain>/
-      tar -xzf "${archive}" -C / 2>/dev/null || {
+      tar --zstd -xf "${archive}" -C / 2>/dev/null || {
         log_error "restore: failed to extract files"
         exit 1
       }
@@ -160,7 +163,7 @@ main() {
 
   # 5. Restore database
   if [ "${SKIP_DB}" != "1" ]; then
-    local sql_dump="${restore_dir}/database.sql"
+    local sql_dump="${restore_dir}/database.sql.zst"
     if [ ! -f "${sql_dump}" ]; then
       log_error "restore: database dump not found: ${sql_dump}"
       log_error "restore: use --skip-db if restoring files only"
@@ -169,11 +172,11 @@ main() {
     log_info "restore: importing database for ${DOMAIN}..."
 
     if [ "${DRY_RUN}" = "1" ]; then
-      log_info "[DRYRUN] would run: sudo -u ${SITE_USER} wp --path=${docroot} db import ${sql_dump}"
+      log_info "[DRYRUN] would run: zstd -dc ${sql_dump} | sudo -u ${SITE_USER} wp --path=${docroot} db import -"
     else
-      sudo -H -u "${SITE_USER}" wp --path="${docroot}" db import "${sql_dump}" 2>/dev/null || {
+      zstd -dc "${sql_dump}" 2>/dev/null | sudo -H -u "${SITE_USER}" wp --path="${docroot}" db import - 2>/dev/null || {
         log_error "restore: wp db import failed"
-        log_error "restore: you may need to run: wp db import ${sql_dump} manually"
+        log_error "restore: you may need to run: zstd -dc ${sql_dump} | wp db import - manually"
         exit 1
       }
       log_info "restore: database imported"

--- a/backup/backup-site.sh
+++ b/backup/backup-site.sh
@@ -117,6 +117,9 @@ main() {
   require_root
   validate
 
+  # Default compression is zstd — ensure the binary is present.
+  backup_require_zstd
+
   # Acquire lock — prevent concurrent runs for the same domain
   local lockfile="/var/lock/litesoup-backup-${DOMAIN}.lock"
   exec 200>"${lockfile}"
@@ -142,7 +145,7 @@ main() {
   local backup_base="/home/${SITE_USER}/backups/${DOMAIN}"
   local backup_dir="${backup_base}/${ts}"
   local files_archive="${backup_dir}/files"
-  local db_dump="${backup_dir}/database.sql"
+  local db_dump="${backup_dir}/database.sql.zst"
 
   if [ "${DRY_RUN}" != "1" ]; then
     mkdir -p "${backup_dir}"
@@ -170,6 +173,9 @@ backup_dump_db '${DOMAIN}' '${backup_dir}'
     }
     local db_elapsed=$(( $(date +%s) - db_ts ))
     log_info "backup: DB dump OK (${db_elapsed}s) for ${DOMAIN}"
+    if [ "${DRY_RUN}" != "1" ]; then
+      backup_verify_db "${db_dump}" || exit 1
+    fi
   fi
 
   # 4. Backup files
@@ -206,6 +212,9 @@ backup_archive '${docroot}' '${files_archive}'
     }
     local fs_elapsed=$(( $(date +%s) - fs_ts ))
     log_info "backup: file archive OK (${fs_elapsed}s) for ${DOMAIN}"
+    if [ "${DRY_RUN}" != "1" ]; then
+      backup_verify_archive "${files_archive}.tar.zst" || exit 1
+    fi
     rm -f "${exclude_file:-}"
   fi
 
@@ -229,10 +238,10 @@ backup_archive '${docroot}' '${files_archive}'
   if [ "${DEST}" = "s3" ] || [ "${DEST}" = "all" ]; then
     log_info "backup: uploading to S3..."
     if [ "${SKIP_DB}" != "1" ]; then
-      backup_s3_upload "${db_dump}" "${DOMAIN}/${ts}/database.sql" || log_warn "backup: S3 upload of database failed"
+      backup_s3_upload "${db_dump}" "${DOMAIN}/${ts}/database.sql.zst" || log_warn "backup: S3 upload of database failed"
     fi
     if [ "${SKIP_FILES}" != "1" ]; then
-      backup_s3_upload "${files_archive}.tar.gz" "${DOMAIN}/${ts}/files.tar.gz" || log_warn "backup: S3 upload of files failed"
+      backup_s3_upload "${files_archive}.tar.zst" "${DOMAIN}/${ts}/files.tar.zst" || log_warn "backup: S3 upload of files failed"
     fi
   fi
 

--- a/backup/lib/common.sh
+++ b/backup/lib/common.sh
@@ -9,11 +9,14 @@
 #   backup_site_user     DOMAIN → SITE_USER   (via /etc/litesoup/vhost/*.conf)
 #   backup_docroot       DOMAIN → path        (via /etc/litesoup/vhost/*.conf)
 #   backup_timestamp     → "YYYY-MM-DD_HHMMSS"
-#   backup_archive       SRCDIR DEST          → tar.gz
-#   backup_dump_db       DOMAIN DEST          → .sql
+#   backup_archive       SRCDIR DEST          → tar.zst
+#   backup_dump_db       DOMAIN DEST          → .sql.zst
 #   backup_rotate_local  BACKUP_DIR KEEP      → prune excess dirs
 #   backup_size_human    PATH                 → "123M" / "1.2G"
 #   backup_validate_name DOMAIN               → safe string (alphanum + dots)
+#   backup_require_zstd  —                    → ensure zstd is installed
+#   backup_verify_archive ARCHIVE             → zstd -t integrity check
+#   backup_verify_db     DUMP                 → integrity + CREATE TABLE check
 
 [ -n "${LITESOUP_BACKUP_COMMON_SH:-}" ] && return 0
 LITESOUP_BACKUP_COMMON_SH=1
@@ -85,7 +88,10 @@ backup_docroot() {
 
 # ---- file archive ----------------------------------------------------------
 
-# backup_archive SRCDIR DEST — creates SRCDIR/DEST.tar.gz
+# backup_archive SRCDIR DEST — creates SRCDIR/DEST.tar.zst (zstd-compressed).
+# Media (already-compressed jpg/png) barely compresses with any tool, so we
+# use zstd -1: ~12x faster than gzip -6 with the same ratio (benchmarked on
+# sg10, 2026-08-29 — team-rd #17).
 # Skips patterns listed in a global exclude file if present.
 backup_archive() {
   local srcdir="${1:?backup_archive: srcdir required}"
@@ -98,9 +104,9 @@ backup_archive() {
     return 1
   fi
 
-  log_info "backup: archiving ${srcdir} → ${dest}.tar.gz"
+  log_info "backup: archiving ${srcdir} → ${dest}.tar.zst"
   if [ "${DRY_RUN}" = "1" ]; then
-    log_info "[DRYRUN] would tar -czf ${dest}.tar.gz -C $(dirname "${srcdir}") $(basename "${srcdir}")"
+    log_info "[DRYRUN] would tar -cf - -C $(dirname "${srcdir}") $(basename "${srcdir}") | zstd -1 > ${dest}.tar.zst"
     return 0
   fi
 
@@ -115,19 +121,21 @@ backup_archive() {
     done < "${REPO_ROOT}/backup/backup-exclude-global.txt"
   fi
 
-  tar -czf "${dest}.tar.gz" \
+  tar -cf - \
     "${exclude_opts[@]}" \
     -C "$(dirname "${srcdir}")" \
-    "$(basename "${srcdir}")" 2>/dev/null
-  log_info "backup: archive created ($(backup_size_human "${dest}.tar.gz"))"
+    "$(basename "${srcdir}")" 2>/dev/null | zstd -1 > "${dest}.tar.zst"
+  log_info "backup: archive created ($(backup_size_human "${dest}.tar.zst"))"
 }
 
 # ---- database dump ---------------------------------------------------------
 
-# backup_dump_db DOMAIN DEST — uses wp-cli to export the site's database.
-# DEST/database.sql is created with mode 0600 owned by root.
+# backup_dump_db DOMAIN DEST — uses wp-cli to export the site's database and
+# compress it with zstd -8 (2x faster + ~40% smaller than gzip -6 on SQL text;
+# benchmarked on sg10, 2026-08-29 — team-rd #17).
+# DEST/database.sql.zst is created with mode 0600 owned by root.
 # Discovers docroot via backup_docroot(), then runs:
-#   sudo -u SITE_USER wp --path=DOCROOT db export DEST/database.sql
+#   sudo -u SITE_USER wp --path=DOCROOT db export - | zstd -8 > DEST/database.sql.zst
 backup_dump_db() {
   local domain="${1:?backup_dump_db: domain required}"
   local dest_dir="${2:?backup_dump_db: dest_dir required}"
@@ -141,20 +149,20 @@ backup_dump_db() {
     return 1
   fi
 
-  log_info "backup: dumping database for ${domain} → ${dest_dir}/database.sql"
+  log_info "backup: dumping database for ${domain} → ${dest_dir}/database.sql.zst"
   if [ "${DRY_RUN}" = "1" ]; then
-    log_info "[DRYRUN] would run: sudo -u ${user} wp --path=${docroot} db export ${dest_dir}/database.sql"
+    log_info "[DRYRUN] would run: sudo -u ${user} wp --path=${docroot} db export - | zstd -8 > ${dest_dir}/database.sql.zst"
     return 0
   fi
 
   mkdir -p "${dest_dir}"
   chown "${user}:${user}" "${dest_dir}"
-  sudo -H -u "${user}" wp --path="${docroot}" db export "${dest_dir}/database.sql" 2>/dev/null || {
+  sudo -H -u "${user}" wp --path="${docroot}" db export - 2>/dev/null | zstd -8 > "${dest_dir}/database.sql.zst" || {
     log_error "backup: wp db export failed for ${domain}"
     return 1
   }
-  chmod 0600 "${dest_dir}/database.sql"
-  log_info "backup: database exported ($(backup_size_human "${dest_dir}/database.sql"))"
+  chmod 0600 "${dest_dir}/database.sql.zst"
+  log_info "backup: database exported ($(backup_size_human "${dest_dir}/database.sql.zst"))"
 }
 
 # ---- local rotation --------------------------------------------------------
@@ -212,4 +220,51 @@ backup_size_human() {
   else
     printf '%.1f GB' "$(echo "scale=1; ${bytes} / 1073741824" | bc 2>/dev/null || echo 0)"
   fi
+}
+
+# ---- compression dependency + verification ---------------------------------
+
+# backup_require_zstd — ensure the zstd binary is available (runtime dep of the
+# default compression). Installs it via apt if missing.
+backup_require_zstd() {
+  if ! command -v zstd &>/dev/null; then
+    log_info "backup: installing zstd"
+    ensure_pkgs zstd
+  fi
+}
+
+# backup_verify_archive ARCHIVE — integrity-check a zstd-compressed archive
+# (files.tar.zst). Runs `zstd -t`; fails loudly if corrupt.
+backup_verify_archive() {
+  local archive="${1:?backup_verify_archive: archive required}"
+  if [ ! -f "${archive}" ]; then
+    log_error "backup: archive not found for verification: ${archive}"
+    return 1
+  fi
+  zstd -t "${archive}" 2>/dev/null || {
+    log_error "backup: archive integrity check FAILED: ${archive}"
+    return 1
+  }
+  log_info "backup: archive integrity OK: ${archive}"
+}
+
+# backup_verify_db DUMP — verify a zstd-compressed SQL dump: runs `zstd -t`,
+# then decompresses and asserts at least one `CREATE TABLE` statement exists.
+backup_verify_db() {
+  local dump="${1:?backup_verify_db: dump required}"
+  if [ ! -f "${dump}" ]; then
+    log_error "backup: db dump not found for verification: ${dump}"
+    return 1
+  fi
+  zstd -t "${dump}" 2>/dev/null || {
+    log_error "backup: db dump integrity check FAILED: ${dump}"
+    return 1
+  }
+  local tables
+  tables="$(zstd -dc "${dump}" 2>/dev/null | grep -c 'CREATE TABLE' || true)"
+  if [ "${tables}" -lt 1 ]; then
+    log_error "backup: db dump verification FAILED (no CREATE TABLE found): ${dump}"
+    return 1
+  fi
+  log_info "backup: db dump verified (${tables} CREATE TABLE statements): ${dump}"
 }

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -28,6 +28,22 @@ sudo bash backup/backup-site.sh --domain=example.com --skip-files
 
 Each backup is stored at `/home/<user>/backups/<domain>/<timestamp>/`.
 
+## Compression (zstd default)
+
+Since v0.11.0, backups use **zstd** as the default compression instead of
+gzip — it is ~2x faster on SQL dumps and ~12x faster on media with equal or
+better ratios (benchmarked on sg10, 2026-08-29 — team-rd #17):
+
+| Artifact | Command | Output |
+|----------|---------|--------|
+| Database | `wp db export - \| zstd -8` | `database.sql.zst` |
+| Files     | `tar cf - \| zstd -1` | `files.tar.zst` |
+
+Archives are verified after creation (`zstd -t`, and `CREATE TABLE` presence
+for DB dumps). Restore transparently decompresses both formats. `zstd` is
+installed automatically during `install-stack.sh` (backup stage) and on-demand
+by the backup/restore scripts if missing.
+
 ## Restore from backup
 
 ```bash
@@ -219,7 +235,7 @@ litesoup uses `s3cmd` which works with any S3-compatible API:
   cannot read each other's backups
 - S3 credentials are stored in `/etc/litesoup/backup-s3.conf` (mode `0600`)
 - Database dumps are created via `wp db export`, inheriting WordPress's
-  database credentials (no hardcoded passwords)
+  database credentials (no hardcoded passwords), and compressed with zstd
 - Restore runs as root but drops to the site user for `wp db import`
 - Temp `.s3cfg` files (credential-bearing) are cleaned up after each S3
   operation; stale files older than 1 hour are purged automatically

--- a/install/install-stack.sh
+++ b/install/install-stack.sh
@@ -373,6 +373,9 @@ main() {
   # operator is ready).
   local backup_stage=$(( total_stages + 1 ))
   log_info "stage ${backup_stage}/${total_stages}: backup scripts + notification"
+  # zstd is the default backup compression — ensure it's installed so new
+  # instances produce .zst archives out of the box.
+  run_or_dryrun ensure_pkgs zstd
   local repo_backup="${repo_root}/backup"
   if [ -d "${repo_backup}" ]; then
     run_or_dryrun install -d -m 0755 "${litesoup_lib}/backup/lib"


### PR DESCRIPTION
## Summary

Make **zstd** the default compression for the litesoup backup system, replacing gzip. Based on the real benchmark from **team-rd/baocao !17** (sg10, 2026-08-29).

| Artifact | Before | After |
|----------|--------|-------|
| Database | `wp db export` → `database.sql` (uncompressed) | `wp db export - \| zstd -8` → `database.sql.zst` |
| Files | `tar -czf` → `files.tar.gz` | `tar cf - \| zstd -1` → `files.tar.zst` |

**Why:** zstd is ~2x faster on SQL dumps (and ~40% smaller) and ~12x faster on media with equal ratio. Media barely compresses with any tool, so gzip wasted ~115s CPU/GB.

## Changes
- `backup/lib/common.sh` — `backup_archive` + `backup_dump_db` emit `.zst`; add `backup_require_zstd`, `backup_verify_archive` (`zstd -t`), `backup_verify_db` (`zstd -t` + `CREATE TABLE` presence)
- `backup/backup-site.sh` — `.zst` filenames, ensure zstd, verify archives after creation, S3 upload names
- `backup/backup-restore.sh` — transparently decompress `.zst` on restore (`tar --zstd`, `zstd -dc \| wp db import -`)
- `backup/backup-list.sh` — detect `.zst` artifacts
- `install/install-stack.sh` — install `zstd` in the backup stage (provisioning)
- `docs/backup.md` + `CHANGELOG.md` — document zstd default

## Testing
- `bash -n` passes on all modified scripts
- `bats test/bats/unit_backup.bats` — 27/27 pass
- `backup_verify_db` / `backup_verify_archive` smoke-tested against a real zstd-compressed dump

Closes codetot-agents/team-product/baocao#13